### PR TITLE
Update Biome command in NextJS CI workflow

### DIFF
--- a/.github/workflows/nextjs.yaml
+++ b/.github/workflows/nextjs.yaml
@@ -46,7 +46,7 @@ jobs:
           version: latest
 
       - name: Run Biome
-        run: biome ci
+        run: pnpm check:ci
 
       - name: Run Vitest
         run: pnpm test


### PR DESCRIPTION
Replace the Biome command with `pnpm check:ci` in the NextJS workflow to improve the CI process.