### PR TITLE
fix(ci): update NextJS workflow to run Biome directly for CI checks

### DIFF
--- a/.github/workflows/nextjs.yaml
+++ b/.github/workflows/nextjs.yaml
@@ -46,7 +46,7 @@ jobs:
           version: latest
 
       - name: Run Biome
-        run: pnpm check:ci
+        run: biome ci ./src
 
       - name: Run Vitest
         run: pnpm test

--- a/learn_nextjs/package.json
+++ b/learn_nextjs/package.json
@@ -13,7 +13,6 @@
     "format:check": "biome format ./src",
     "check": "biome check ./src",
     "check:fix": "biome check --write ./src",
-    "check:ci": "biome ci ./src",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
Revise the NextJS CI workflow to execute Biome directly for checks, enhancing the build process. Remove the obsolete `check:ci` script from the package.json.