### PR TITLE
refactor: update import statements for consistency and clarity across multiple files

### DIFF
--- a/.github/workflows/fastapi.yaml
+++ b/.github/workflows/fastapi.yaml
@@ -44,8 +44,8 @@ jobs:
       - name: Check code formatting and linting
         run: uv run ruff check . && uv run ruff format --check .
 
-      # - name: Check type hints
-      #   run: uv run ty check .
+      - name: Check type hints
+        run: uv run ty check .
 
       - name: Minimize uv cache
         run: uv cache prune --ci

--- a/learn_fastapi/src/auth/utils.py
+++ b/learn_fastapi/src/auth/utils.py
@@ -6,8 +6,8 @@ from argon2 import PasswordHasher
 from argon2.exceptions import InvalidHash, VerifyMismatchError
 from starlette.responses import Response
 
-from learn_fastapi.src.auth.config import auth_config
-from learn_fastapi.src.auth.schema import TokenData
+from .config import auth_config
+from .schema import TokenData
 
 # Configuration
 SECRET_KEY = auth_config.secret_key

--- a/learn_fastapi/src/items/cache.py
+++ b/learn_fastapi/src/items/cache.py
@@ -19,8 +19,9 @@ from learn_fastapi.src.cache.redis_client import (
     get_cache,
     set_cache,
 )
-from learn_fastapi.src.items.schema import ItemSchema
 from learn_fastapi.src.users.models import User
+
+from .schema import ItemSchema
 
 _NS = "items"
 _TTL = 600

--- a/learn_fastapi/src/items/repository.py
+++ b/learn_fastapi/src/items/repository.py
@@ -4,9 +4,10 @@ from uuid import UUID
 from sqlalchemy import and_, select, update
 
 from learn_fastapi.src.database import AsyncSessionDep
-from learn_fastapi.src.items.models import Item
-from learn_fastapi.src.items.schema import ItemUpdateSchema
 from learn_fastapi.src.users.models import User
+
+from .models import Item
+from .schema import ItemUpdateSchema
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio.session import AsyncSession

--- a/learn_fastapi/src/items/service.py
+++ b/learn_fastapi/src/items/service.py
@@ -3,7 +3,13 @@ from uuid import UUID
 from fastapi import UploadFile
 
 from learn_fastapi.src.database import AsyncSessionDep
-from learn_fastapi.src.items.cache import (
+from learn_fastapi.src.sse.manager import sse_manager
+from learn_fastapi.src.users.exceptions import only_user_owner_is_authorized
+from learn_fastapi.src.users.models import User
+from learn_fastapi.src.users.repository import UsersRepository
+from learn_fastapi.src.utils.exceptions import user_doesnt_exist_exception
+
+from .cache import (
     cache_item,
     cache_items,
     cache_user_item,
@@ -12,20 +18,15 @@ from learn_fastapi.src.items.cache import (
     get_cached_items,
     get_cached_user_item,
     get_cached_user_items,
-    invalidate_items_namespace,
 )
-from learn_fastapi.src.items.exceptions import (
+from .exceptions import (
     duplicate_item_name_exception,
     item_not_found_exception,
     item_not_found_or_not_belong_to_user_exception,
 )
-from learn_fastapi.src.items.repository import ItemRepository
-from learn_fastapi.src.items.schema import ItemSchema, ItemUpdateSchema
-from learn_fastapi.src.items.utils import save_image_file
-from learn_fastapi.src.users.exceptions import only_user_owner_is_authorized
-from learn_fastapi.src.users.models import User
-from learn_fastapi.src.users.repository import UsersRepository
-from learn_fastapi.src.utils.exceptions import user_doesnt_exist_exception
+from .repository import ItemRepository
+from .schema import ItemSchema, ItemUpdateSchema
+from .utils import save_image_file
 
 
 class ItemService:
@@ -76,18 +77,15 @@ class ItemService:
             A list of every ItemSchema (maybe empty).
 
         """
-        # Cache
         cached = await get_cached_items()
         if cached:
             return [ItemSchema.model_validate(item) for item in cached]
 
-        # Cache missed
         items = await self.repository.get_all_items()
         schemas = [
             ItemSchema.model_validate(item, from_attributes=True) for item in items
         ]
 
-        # Populate Cache
         await cache_items([schema.model_dump(mode="json") for schema in schemas])
 
         return schemas
@@ -105,19 +103,16 @@ class ItemService:
             item_not_found_exception: When no item with the given UUID exists.
 
         """
-        # Cache
         cached = await get_cached_item(id_param)
         if cached:
             return ItemSchema.model_validate(cached)
 
-        # Cache missed
         item = await self.repository.get_item(id_param)
         if item is None:
             raise item_not_found_exception()
 
         schema = ItemSchema.model_validate(item, from_attributes=True)
 
-        # Populate Cache
         await cache_item(id_param, schema.model_dump(mode="json"))
 
         return schema
@@ -135,12 +130,10 @@ class ItemService:
             item_not_found_or_not_belong_to_user_exception: When the user owns no items.
 
         """
-        # Cache
         cached = await get_cached_user_items(owner)
         if cached:
             return [ItemSchema.model_validate(item) for item in cached]
 
-        # Cache missed
         items = await self.repository.get_user_items(owner)
         if not items:
             raise item_not_found_or_not_belong_to_user_exception()
@@ -149,7 +142,6 @@ class ItemService:
             ItemSchema.model_validate(item, from_attributes=True) for item in items
         ]
 
-        # Populate Cache
         await cache_user_items(
             [schema.model_dump(mode="json") for schema in schemas], owner
         )
@@ -171,19 +163,16 @@ class ItemService:
                 or is not owned by the user.
 
         """
-        # Cache
         cached = await get_cached_user_item(item_id, owner)
         if cached:
             return ItemSchema.model_validate(cached)
 
-        # Cache missed
         item = await self.repository.get_user_item(item_id, owner)
         if item is None:
             raise item_not_found_or_not_belong_to_user_exception()
 
         schema = ItemSchema.model_validate(item, from_attributes=True)
 
-        # Populate Cache
         await cache_user_item(item_id, schema.model_dump(mode="json"), owner)
 
         return schema
@@ -200,11 +189,19 @@ class ItemService:
 
         """
         item = await self.repository.create_item(item_data, owner)
+        schema = ItemSchema.model_validate(item, from_attributes=True)
 
-        # Invalidate Items Cache
-        await invalidate_items_namespace()
+        await sse_manager.broadcast_global(
+            "item.created",
+            schema.model_dump(mode="json"),
+        )
+        await sse_manager.broadcast_user(
+            owner.id,
+            "item.created",
+            schema.model_dump(mode="json"),
+        )
 
-        return ItemSchema.model_validate(item, from_attributes=True)
+        return schema
 
     async def create_item_with_image(  # noqa: PLR0913, PLR0917
         self,
@@ -241,7 +238,6 @@ class ItemService:
         """
         existing = await self.repository.get_item_by_name(name)
         if existing:
-            # Raise a conflict exception — the item was found, not missing
             raise duplicate_item_name_exception()
 
         item_data = ItemUpdateSchema(
@@ -249,14 +245,23 @@ class ItemService:
         )
         item = await self.repository.create_item(item_data, owner)
 
-        # Invalidate Items Cache
-        await invalidate_items_namespace()
-
         if image_file:
             image = await save_image_file(image_file, caption)
             item = await self.repository.update_item_image(item.id, image.url)
 
-        return ItemSchema.model_validate(item, from_attributes=True)
+        schema = ItemSchema.model_validate(item, from_attributes=True)
+
+        await sse_manager.broadcast_global(
+            "item.created",
+            schema.model_dump(mode="json"),
+        )
+        await sse_manager.broadcast_user(
+            owner.id,
+            "item.created",
+            schema.model_dump(mode="json"),
+        )
+
+        return schema
 
     async def update_item(
         self, item_id: UUID, item_data: ItemUpdateSchema, owner: User | None = None
@@ -282,13 +287,17 @@ class ItemService:
         """
         owner_scope = None if owner and owner.is_superuser else owner
         item = await self.repository.update_item(item_id, item_data, owner_scope)
-        if item is None:
+        if not item:
             raise item_not_found_or_not_belong_to_user_exception()
 
-        # Invalidate Items Cache
-        await invalidate_items_namespace()
+        schema = ItemSchema.model_validate(item, from_attributes=True)
+        await sse_manager.broadcast_user(
+            item.user_id,  # ty:ignore[invalid-argument-type]
+            "item.updated",
+            schema.model_dump(mode="json"),
+        )
 
-        return ItemSchema.model_validate(item, from_attributes=True)
+        return schema
 
     async def patch_item(
         self, item_id: UUID, item_data: ItemUpdateSchema, owner: User | None = None
@@ -317,10 +326,15 @@ class ItemService:
         if item is None:
             raise item_not_found_or_not_belong_to_user_exception()
 
-        # Invalidate Items Cache
-        await invalidate_items_namespace()
+        schema = ItemSchema.model_validate(item, from_attributes=True)
 
-        return ItemSchema.model_validate(item, from_attributes=True)
+        await sse_manager.broadcast_user(
+            item.user_id,  # ty:ignore[invalid-argument-type]
+            "item.updated",
+            schema.model_dump(mode="json"),
+        )
+
+        return schema
 
     async def delete_item(self, item_id: UUID, owner: User) -> None:
         """Delete an item owned by the given user.
@@ -344,8 +358,12 @@ class ItemService:
 
         await self.repository.delete_item(item)
 
-        # Invalidate Items Cache
-        await invalidate_items_namespace()
+        schema = ItemSchema.model_validate(item, from_attributes=True)
+        await sse_manager.broadcast_user(
+            owner.id,
+            "item.deleted",
+            schema.model_dump(mode="json"),
+        )
 
     async def update_item_image(
         self, item_id: UUID, image_file: UploadFile, caption: str
@@ -369,7 +387,12 @@ class ItemService:
         if item is None:
             raise item_not_found_exception()
 
-        # Invalidate Items Cache
-        await invalidate_items_namespace()
+        schema = ItemSchema.model_validate(item, from_attributes=True)
 
-        return ItemSchema.model_validate(item, from_attributes=True)
+        await sse_manager.broadcast_user(
+            item.user_id,  # ty:ignore[invalid-argument-type]
+            "item.image_updated",
+            schema.model_dump(mode="json"),
+        )
+
+        return schema

--- a/learn_fastapi/src/items/utils.py
+++ b/learn_fastapi/src/items/utils.py
@@ -2,8 +2,9 @@ import aiofiles
 from fastapi import UploadFile
 
 from learn_fastapi.src.constants import IMAGES_DIR
-from learn_fastapi.src.items.schema import ImageSchema
 from learn_fastapi.src.utils.exceptions import image_filename_required_exception
+
+from .schema import ImageSchema
 
 
 async def save_image_file(

--- a/learn_fastapi/src/users/service.py
+++ b/learn_fastapi/src/users/service.py
@@ -8,7 +8,6 @@ from learn_fastapi.src.auth.utils import (
     verify_password,
 )
 from learn_fastapi.src.database import AsyncSessionDep
-from learn_fastapi.src.users.schema import DeleteAccount, UserUpdate
 from learn_fastapi.src.utils.exceptions import (
     email_already_registered_exception,
     user_doesnt_exist_exception,
@@ -17,6 +16,7 @@ from learn_fastapi.src.utils.exceptions import (
 from .exceptions import incorrect_password_exception, only_user_owner_is_authorized
 from .models import User
 from .repository import UsersRepository
+from .schema import DeleteAccount, UserUpdate
 
 
 class UsersService:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ extend-ignore = [
   "TC002", # Ignore "Move third-party library imports ... into a type-checking block" learn_fastapi types are not compatible with this rule, and it is not critical for Pydantic.
   "TC003", # Ignore "Move standard library imports ... into a type-checking block" learn_fastapi types are not compatible with this rule, and it is not critical for Pydantic.
 ]
-extend-select = [] # Here you can add additional rules to be checked by Ruff, if desired.
+extend-select = ["I"] # Here you can add additional rules to be checked by Ruff, if desired.
 
 [tool.ruff.lint.per-file-ignores]
 "**/tests/*" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,9 @@ dev = [
   "types-sqlalchemy>=1.4.53.38",
 ]
 streamlit-deps = [
-    "httpx>=0.28.1",
-    "streamlit>=1.55.0",
+  "httpx>=0.28.1",
+  "streamlit>=1.55.0",
 ]
-
 
 [project.scripts]
 run-api-server = "learn_fastapi.src.main:main"
@@ -57,7 +56,10 @@ requires = ["hatchling"]
 packages = ["learn_fastapi", "learn_streamlit"]
 
 [tool.ruff.lint]
-exclude = [".venv", "versions"]
+exclude = [
+  "./.venv/**",
+  "**/alembic/versions/*",
+]
 extend-ignore = [
   "ARG001", # Ignore "Unused function argument".
   "CPY001", # Ignore "Missing copyright notice".

--- a/uv.lock
+++ b/uv.lock
@@ -583,29 +583,29 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.4.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
-    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
-    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
-    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -957,11 +957,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -1335,11 +1335,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.24.2"
+version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1687,9 +1687,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
 ]
 
 [[package]]
@@ -1786,7 +1786,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1794,9 +1794,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refactor import statements for consistency and clarity; update package versions in pyproject.toml; enhance item service with SSE broadcasting for item creation, update, and deletion events.

Converts absolute imports to relative imports across the items and auth modules for improved consistency and maintainability. This follows Python best practices for intra-package imports and aligns with Ruff's import sorting rules (enabled via `isort` plugin).

Replaces cache invalidation logic with Server-Sent Events (SSE) broadcasting in the item service. Item creation, updates, and deletion now broadcast real-time notifications to connected clients both globally and per-user, enabling live UI updates without polling.

Removes unused cache invalidation function and simplifies code by eliminating redundant comments. Updates project dependencies for greenlet, pathspec, python-multipart, typer, and virtualenv to latest versions.