### PR TITLE
feat(auth): fix refresh token endpoint to work without current user authentication

### DIFF
--- a/learn_nextjs/package.json
+++ b/learn_nextjs/package.json
@@ -16,7 +16,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "tsc": "tsgo --noEmit"
+    "tsc": "tsgo --noEmit",
+    "prepare": "effect-tsgo patch"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -52,7 +53,8 @@
     "shadcn": "^4.4.0",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "@effect/tsgo": "0.5.2"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mts,cts,json,css}": [

--- a/learn_nextjs/pnpm-lock.yaml
+++ b/learn_nextjs/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.12
         version: 2.4.12
+      '@effect/tsgo':
+        specifier: 0.5.2
+        version: 0.5.2
       '@tailwindcss/postcss':
         specifier: ^4.2.4
         version: 4.2.4
@@ -338,6 +341,45 @@ packages:
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
+
+  '@effect/tsgo-darwin-arm64@0.5.2':
+    resolution: {integrity: sha512-GGlnLSbHNASNcGxr96qzZyifvMPb/jFYPk8sNptG9flZJgjqxybrxL/1qrS1MAwG8APgD1BkkL1NuSuAofg46Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@effect/tsgo-darwin-x64@0.5.2':
+    resolution: {integrity: sha512-nBhPST7ZV3aJLh0vRN84ah/Ot2MyPyDax2EbvPSfJJealmUPUxi5HYOVdaY7w96lgNhmUsG9p0dLBHePK6OZmw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@effect/tsgo-linux-arm64@0.5.2':
+    resolution: {integrity: sha512-ofkPn1thptZCxcoycCJOL18FIeqc92u1xg/k2Z6v2WpyTFXXM2m8DVKro6WVOJ88izq2NkaqF3TssUhX6wWxJA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@effect/tsgo-linux-arm@0.5.2':
+    resolution: {integrity: sha512-+4xV9rltFIUGPYGQvqnwsfylDeKZCQiYQHjLw1GrY8ZdVDAKWZM4z/fW4durf+WZcQsu9myS46wbgY6wMzapHw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@effect/tsgo-linux-x64@0.5.2':
+    resolution: {integrity: sha512-V6sHIZlKQv693ABb9REX0RzIvzyCbNg2uP5+4MXwetlSxz8pmeAUCpraAQLXBkKlYL5rG9kMIobDFU9A88Nqig==}
+    cpu: [x64]
+    os: [linux]
+
+  '@effect/tsgo-win32-arm64@0.5.2':
+    resolution: {integrity: sha512-duderlpvUtI25NON88K9ii9vpOmJoCF7On2lh8wY6LXMSXw6whRJSppuhkJp9b5MxSCw85tC0om0bveAoQMtlQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@effect/tsgo-win32-x64@0.5.2':
+    resolution: {integrity: sha512-MCFRUI54cHuvZmnn//rOqu+ShrVSqgr2gIctPfa3L40GNUnAZ2fx/3diGZV7uSysZRMKnrz+zgGtcSM/36W6Og==}
+    cpu: [x64]
+    os: [win32]
+
+  '@effect/tsgo@0.5.2':
+    resolution: {integrity: sha512-LEKmx1rwP1j3l9mPW6Bx8VIdGKW+uEvvML89z4xiWnPC+h/uFm3y6FGHULop9Kl09Ybwn2TVuZzVPSZLj+ydmg==}
+    hasBin: true
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -2871,6 +2913,37 @@ snapshots:
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
+
+  '@effect/tsgo-darwin-arm64@0.5.2':
+    optional: true
+
+  '@effect/tsgo-darwin-x64@0.5.2':
+    optional: true
+
+  '@effect/tsgo-linux-arm64@0.5.2':
+    optional: true
+
+  '@effect/tsgo-linux-arm@0.5.2':
+    optional: true
+
+  '@effect/tsgo-linux-x64@0.5.2':
+    optional: true
+
+  '@effect/tsgo-win32-arm64@0.5.2':
+    optional: true
+
+  '@effect/tsgo-win32-x64@0.5.2':
+    optional: true
+
+  '@effect/tsgo@0.5.2':
+    optionalDependencies:
+      '@effect/tsgo-darwin-arm64': 0.5.2
+      '@effect/tsgo-darwin-x64': 0.5.2
+      '@effect/tsgo-linux-arm': 0.5.2
+      '@effect/tsgo-linux-arm64': 0.5.2
+      '@effect/tsgo-linux-x64': 0.5.2
+      '@effect/tsgo-win32-arm64': 0.5.2
+      '@effect/tsgo-win32-x64': 0.5.2
 
   '@emnapi/core@1.9.1':
     dependencies:

--- a/learn_nextjs/src/__tests__/schemas/items/itemFormSchema.test.ts
+++ b/learn_nextjs/src/__tests__/schemas/items/itemFormSchema.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { itemFormSchema } from '@/schemas/items/forms'
+import { itemCreateFormSchema } from '@/schemas/items/forms'
 
 // Helper — simulates FormData entries converted to a plain object
-const parse = (data: Record<string, unknown>) => itemFormSchema.safeParse(data)
+const parse = (data: Record<string, unknown>) =>
+  itemCreateFormSchema.safeParse(data)
 
 const VALID_INPUT = {
   name: 'Running Shoes',

--- a/learn_nextjs/src/actions/auth/actions.ts
+++ b/learn_nextjs/src/actions/auth/actions.ts
@@ -8,30 +8,41 @@ import { login, logout, signup } from '@/app/api/server-endpoints'
 import { TokenV2Schema, UserCreateSchema } from '@/common/schemas/api/resources'
 import type { AuthActionState } from '@/types/auth/types'
 
-const processAuthFormData = (formData: FormData) => {
+const baseAuthAction = async (formData: FormData) => {
   const email = formData.get('email')
   const password = formData.get('password')
   const rawRedirect = formData.get('redirectPath')
   const redirectPath = getSafeNextPath(
     typeof rawRedirect === 'string' ? rawRedirect : undefined
   )
-  return { data: { email, password }, redirectPath }
+  const data = { email, password }
+
+  const parsed = UserCreateSchema.safeParse(data)
+  if (!parsed.success) {
+    return {
+      success: false,
+      error: parsed.error.issues[0]?.message ?? 'Invalid input'
+    }
+  }
+
+  return { success: true, parsed: parsed.data, redirectPath }
 }
 
 export const loginAction = async (
   _prevState: AuthActionState,
   formData: FormData
 ): Promise<AuthActionState> => {
-  const { data, redirectPath } = processAuthFormData(formData)
+  const baseResult = await baseAuthAction(formData)
 
-  const parsed = UserCreateSchema.safeParse(data)
-  if (!parsed.success) {
-    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  if (!baseResult.success || !baseResult.parsed || !baseResult.redirectPath) {
+    return { error: baseResult.error ?? `Failed to process auth data` }
   }
 
   const body = new URLSearchParams()
-  body.set('username', parsed.data.email)
-  body.set('password', parsed.data.password)
+
+  const { email, password } = baseResult.parsed
+  body.set('username', email)
+  body.set('password', password)
 
   const response = await login(body)
   if (!response.data || response.error) {
@@ -68,25 +79,20 @@ export const loginAction = async (
     secure: isProduction
   })
 
-  redirect(redirectPath)
+  redirect(baseResult.redirectPath)
 }
 
 export const registerAction = async (
   _prevState: AuthActionState,
   formData: FormData
 ): Promise<AuthActionState> => {
-  const { data, redirectPath } = processAuthFormData(formData)
+  const baseResult = await baseAuthAction(formData)
 
-  const parsed = UserCreateSchema.safeParse(data)
-  if (!parsed.success) {
-    return { error: parsed.error.issues[0]?.message ?? 'Invalid input' }
+  if (!baseResult.success || !baseResult.parsed || !baseResult.redirectPath) {
+    return { error: baseResult.error ?? `Failed to process auth data` }
   }
 
-  const parsedData = {
-    email: parsed.data.email,
-    password: parsed.data.password
-  }
-  const response = await signup(parsedData)
+  const response = await signup(baseResult.parsed)
 
   if (!response.data || response.error) {
     return {
@@ -94,7 +100,7 @@ export const registerAction = async (
     }
   }
 
-  redirect(redirectPath)
+  redirect(baseResult.redirectPath)
 }
 
 export const logoutAction = async () => {

--- a/learn_nextjs/src/actions/items/actions.ts
+++ b/learn_nextjs/src/actions/items/actions.ts
@@ -1,65 +1,146 @@
 'use server'
 
-import { revalidateTag } from 'next/cache'
+import { revalidateTag, updateTag } from 'next/cache'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { z } from 'zod'
 
-import { createItem, getMe } from '@/app/api/server-endpoints'
-import { ItemSchema, UserSchema } from '@/common/schemas/api/resources'
-import { itemFormSchema } from '@/schemas/items/forms'
+import { createItem, getMe, updateItem } from '@/app/api/server-endpoints'
+import type { CreateItemRequest, PatchItemRequest } from '@/app/api/types'
+import {
+  ItemPatchSchema,
+  ItemSchema,
+  UserSchema
+} from '@/common/schemas/api/resources'
+import {
+  itemCreateFormSchema,
+  itemPatchFormSchema
+} from '@/schemas/items/forms'
 import type { ItemActionState } from '@/types/items/types'
+import type { ItemBaseResult, itemFormSchemas } from '../types'
 
-export const createItemAction = async (
-  _prevState: ItemActionState,
-  formData: FormData
-): Promise<ItemActionState> => {
-  const cookieStore = await cookies()
-  const accessToken = cookieStore.get('access_token')?.value
+const itemBaseAction = async <T extends itemFormSchemas>(
+  formData: FormData,
+  itemSchema: T
+): Promise<ItemBaseResult<T>> => {
+  const accessToken = (await cookies()).get('access_token')?.value
   if (!accessToken) {
-    return { error: 'Authentication required. Please log in.' }
+    return { success: false, error: 'Authentication required. Please log in.' }
   }
 
   const { data: meData, error: meError } = await getMe(accessToken)
   if (meError || !meData) {
     return {
+      success: false,
       error: `Failed to verify authentication: ${meError ?? 'Unknown error'}.`
     }
   }
 
   const userResult = UserSchema.safeParse(meData)
   if (!userResult.success) {
-    return { error: 'Failed to verify user identity.' }
+    return { success: false, error: 'Failed to verify user identity.' }
   }
 
   const userId = userResult.data.id
   const rawFormData = Object.fromEntries(formData.entries())
-  const parseResult = itemFormSchema.safeParse(rawFormData)
-
+  const parseResult = itemSchema.safeParse(rawFormData)
   if (!parseResult.success) {
     const flatErrors = z.flattenError(parseResult.error).fieldErrors
     const firstError = Object.values(flatErrors).flat()[0]
-    return { error: firstError ?? 'Invalid form data.' }
+    return { success: false, error: firstError ?? 'Invalid form data.' }
   }
 
-  const itemData = { user_id: userId, ...parseResult.data }
-
-  const { data: newItem, error } = await createItem(itemData, accessToken)
-  if (error || !newItem) {
+  if (itemSchema === itemCreateFormSchema) {
     return {
-      error: `Failed to create item: ${error ?? 'Unknown error'}.`
+      success: true,
+      userId,
+      itemData: {
+        user_id: userId,
+        ...parseResult.data
+      } as CreateItemRequest,
+      accessToken
+    } as ItemBaseResult<T>
+  }
+
+  return {
+    success: true,
+    userId,
+    itemData: {
+      user_id: userId,
+      ...parseResult.data
+    } as PatchItemRequest,
+    accessToken
+  } as ItemBaseResult<T>
+}
+
+export const createItemAction = async (
+  _prevState: ItemActionState,
+  formData: FormData
+): Promise<ItemActionState> => {
+  const baseResult = await itemBaseAction(formData, itemCreateFormSchema)
+
+  if (!baseResult.success) {
+    return { error: baseResult.error ?? 'Failed to process item data.' }
+  }
+
+  const { data: newItem, error: createError } = await createItem(
+    baseResult.itemData,
+    baseResult.accessToken
+  )
+  if (createError || !newItem) {
+    return {
+      error: `Failed to create item: ${createError ?? 'Unknown error'}.`
     }
   }
 
-  const itemResult = ItemSchema.safeParse(newItem)
+  const { success, error } = ItemSchema.safeParse(newItem)
   revalidateTag('items', 'max')
 
-  if (itemResult.success) {
-    redirect(`/items/${itemResult.data.id}`)
+  if (!success) {
+    return {
+      error: `Item created but failed to parse item data: ${
+        JSON.stringify(error?.message) ?? 'Unknown error'
+      }.`
+    }
   }
 
-  console.error(
-    `Unexpectedly created item but failed to parse it: ${JSON.stringify(itemResult.error.message)}`
+  redirect(`/items/${newItem.id}`)
+}
+
+export const updateItemAction = async (
+  _prevState: ItemActionState,
+  formData: FormData,
+  itemId: string
+): Promise<ItemActionState> => {
+  const baseResult = await itemBaseAction(formData, itemPatchFormSchema)
+
+  if (!baseResult.success) {
+    return { error: baseResult.error ?? 'Failed to process item data.' }
+  }
+
+  const { data: updatedItem, error: updateError } = await updateItem(
+    itemId,
+    baseResult.itemData,
+    baseResult.accessToken
   )
-  redirect('/items')
+
+  if (updateError || !updatedItem) {
+    return {
+      error: `Failed to update item: ${updateError ?? 'Unknown error'}.`
+    }
+  }
+
+  const { success, error } = ItemPatchSchema.safeParse(updatedItem)
+  updateTag('items')
+  updateTag(`item-${itemId}`)
+
+  if (!success) {
+    return {
+      error: `Item updated but failed to parse updated item data: ${
+        JSON.stringify(error?.message) ?? 'Unknown error'
+      }.`
+    }
+  }
+
+  redirect(`/items/${itemId}`)
 }

--- a/learn_nextjs/src/actions/types.ts
+++ b/learn_nextjs/src/actions/types.ts
@@ -1,0 +1,27 @@
+import type { CreateItemRequest, PatchItemRequest } from '@/app/api/types'
+import type {
+  itemCreateFormSchema,
+  itemPatchFormSchema
+} from '@/schemas/items/forms'
+
+export type itemFormSchemas =
+  | typeof itemCreateFormSchema
+  | typeof itemPatchFormSchema
+
+type ItemBaseSuccess<T extends itemFormSchemas> = {
+  success: true
+  userId: string
+  accessToken: string
+  itemData: T extends typeof itemCreateFormSchema
+    ? CreateItemRequest
+    : PatchItemRequest
+}
+
+type ItemBaseError = {
+  success: false
+  error: string
+}
+
+export type ItemBaseResult<T extends itemFormSchemas> =
+  | ItemBaseSuccess<T>
+  | ItemBaseError

--- a/learn_nextjs/src/actions/user/actions.ts
+++ b/learn_nextjs/src/actions/user/actions.ts
@@ -1,0 +1,313 @@
+'use server'
+
+import { updateTag } from 'next/cache'
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+import { z } from 'zod'
+
+import {
+  deleteCurrentUser,
+  deleteItem,
+  getItem,
+  getMe,
+  updateCurrentUser,
+  updateItem
+} from '@/app/api/server-endpoints'
+import type { PatchItemRequest } from '@/app/api/types'
+import { itemPatchFormSchema } from '@/schemas/items/forms'
+import type { MeActionState } from '@/types/me/types'
+
+const profileEmailSchema = z.object({
+  email: z.email({
+    pattern: z.regexes.email,
+    message: 'Invalid email address'
+  }),
+  currentPassword: z
+    .string()
+    .min(8, { message: 'Password must be at least 8 characters long' })
+})
+
+const profilePasswordSchema = z
+  .object({
+    currentPassword: z
+      .string()
+      .min(8, { message: 'Password must be at least 8 characters long' }),
+    newPassword: z
+      .string()
+      .min(8, { message: 'Password must be at least 8 characters long' }),
+    confirmPassword: z
+      .string()
+      .min(1, { message: 'Please confirm your password' })
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: 'New password and confirmation must match',
+    path: ['confirmPassword']
+  })
+
+const getAuthenticatedUser = async () => {
+  const accessToken = (await cookies()).get('access_token')?.value
+  if (!accessToken) {
+    return {
+      success: false,
+      error: 'Authentication required. Please log in again.'
+    } as const
+  }
+
+  const { data: me, error } = await getMe(accessToken)
+  if (error || !me) {
+    return {
+      success: false,
+      error: `Failed to verify authentication: ${error ?? 'Unknown error'}.`
+    } as const
+  }
+
+  return {
+    success: true,
+    accessToken,
+    me
+  } as const
+}
+
+const checkItemAuthorization = async (
+  itemId: string,
+  currentUserId: string,
+  isSuperuser: boolean,
+  accessToken: string
+) => {
+  const { data: item, error } = await getItem(itemId)
+  if (error || !item) {
+    return {
+      success: false,
+      error: `Failed to load item: ${error ?? 'Unknown error'}.`
+    } as const
+  }
+
+  if (!isSuperuser && item.user_id !== currentUserId) {
+    return {
+      success: false,
+      error: 'You are not allowed to modify this item.'
+    } as const
+  }
+
+  return {
+    success: true,
+    item,
+    accessToken
+  } as const
+}
+
+export const updateProfileEmailAction = async (
+  _prevState: MeActionState,
+  formData: FormData
+): Promise<MeActionState> => {
+  const authResult = await getAuthenticatedUser()
+  if (!authResult.success) {
+    return { error: authResult.error }
+  }
+
+  const parseResult = profileEmailSchema.safeParse({
+    email: formData.get('email'),
+    currentPassword: formData.get('currentPassword')
+  })
+
+  if (!parseResult.success) {
+    return {
+      error: parseResult.error.issues[0]?.message ?? 'Invalid form data.'
+    }
+  }
+
+  const { data: updatedUser, error } = await updateCurrentUser(
+    authResult.accessToken,
+    {
+      email: parseResult.data.email,
+      current_password: parseResult.data.currentPassword
+    }
+  )
+
+  if (error || !updatedUser) {
+    return {
+      error: `Failed to update profile email: ${error ?? 'Unknown error'}.`
+    }
+  }
+
+  updateTag('items')
+
+  return { success: 'Email updated successfully.' }
+}
+
+export const updateProfilePasswordAction = async (
+  _prevState: MeActionState,
+  formData: FormData
+): Promise<MeActionState> => {
+  const authResult = await getAuthenticatedUser()
+  if (!authResult.success) {
+    return { error: authResult.error }
+  }
+
+  const parseResult = profilePasswordSchema.safeParse({
+    currentPassword: formData.get('currentPassword'),
+    newPassword: formData.get('newPassword'),
+    confirmPassword: formData.get('confirmPassword')
+  })
+
+  if (!parseResult.success) {
+    return {
+      error: parseResult.error.issues[0]?.message ?? 'Invalid form data.'
+    }
+  }
+
+  const { data: updatedUser, error } = await updateCurrentUser(
+    authResult.accessToken,
+    {
+      current_password: parseResult.data.currentPassword,
+      new_password: parseResult.data.newPassword
+    }
+  )
+
+  if (error || !updatedUser) {
+    return {
+      error: `Failed to update password: ${error ?? 'Unknown error'}.`
+    }
+  }
+
+  return { success: 'Password updated successfully.' }
+}
+
+export const deleteAccountAction = async (
+  _prevState: MeActionState,
+  formData: FormData
+): Promise<MeActionState> => {
+  const confirmDelete = formData.get('confirmDelete')
+  if (confirmDelete !== 'DELETE') {
+    return { error: 'Type DELETE to confirm account deletion.' }
+  }
+
+  const authResult = await getAuthenticatedUser()
+  if (!authResult.success) {
+    return { error: authResult.error }
+  }
+
+  const { error } = await deleteCurrentUser(authResult.accessToken)
+
+  if (error) {
+    return {
+      error: `Failed to delete account: ${error}.`
+    }
+  }
+
+  const cookieStore = await cookies()
+  cookieStore.delete('access_token')
+  cookieStore.delete('refresh_token')
+  cookieStore.delete('csrf_token')
+
+  redirect('/signup')
+}
+
+export const updateOwnedItemAction = async (
+  _prevState: MeActionState,
+  formData: FormData
+): Promise<MeActionState> => {
+  const itemId = formData.get('itemId')
+  if (typeof itemId !== 'string' || itemId.length === 0) {
+    return { error: 'Item ID is required.' }
+  }
+
+  const authResult = await getAuthenticatedUser()
+  if (!authResult.success) {
+    return { error: authResult.error }
+  }
+
+  const itemAuthResult = await checkItemAuthorization(
+    itemId,
+    authResult.me.id,
+    authResult.me.is_superuser,
+    authResult.accessToken
+  )
+  if (!itemAuthResult.success) {
+    return { error: itemAuthResult.error }
+  }
+
+  const rawFormData = Object.fromEntries(formData.entries())
+  const parseResult = itemPatchFormSchema.safeParse(rawFormData)
+  if (!parseResult.success) {
+    return {
+      error: parseResult.error.issues[0]?.message ?? 'Invalid form data.'
+    }
+  }
+
+  const rawImageUrl = formData.get('imageUrl')
+  const imageUrl =
+    typeof rawImageUrl === 'string' && rawImageUrl.trim().length > 0
+      ? rawImageUrl.trim()
+      : undefined
+
+  const patchData: PatchItemRequest = {
+    user_id: itemAuthResult.item.user_id,
+    name: parseResult.data.name,
+    description: parseResult.data.description,
+    price: parseResult.data.price,
+    tax: parseResult.data.tax,
+    image_url: imageUrl
+  }
+
+  const hasAnyEditableValue =
+    patchData.name !== undefined ||
+    patchData.description !== undefined ||
+    patchData.price !== undefined ||
+    patchData.tax !== undefined ||
+    patchData.image_url !== undefined
+
+  if (!hasAnyEditableValue) {
+    return { error: 'Please provide at least one field to update.' }
+  }
+
+  const { error } = await updateItem(itemId, patchData, authResult.accessToken)
+
+  if (error) {
+    return {
+      error: `Failed to update item: ${error}.`
+    }
+  }
+
+  updateTag('items')
+  updateTag(`item-${itemId}`)
+
+  return { success: 'Item updated successfully.' }
+}
+
+export const deleteOwnedItemAction = async (
+  _prevState: MeActionState,
+  formData: FormData
+): Promise<MeActionState> => {
+  const itemId = formData.get('itemId')
+  if (typeof itemId !== 'string' || itemId.length === 0) {
+    return { error: 'Item ID is required.' }
+  }
+
+  const authResult = await getAuthenticatedUser()
+  if (!authResult.success) {
+    return { error: authResult.error }
+  }
+
+  const itemAuthResult = await checkItemAuthorization(
+    itemId,
+    authResult.me.id,
+    authResult.me.is_superuser,
+    authResult.accessToken
+  )
+  if (!itemAuthResult.success) {
+    return { error: itemAuthResult.error }
+  }
+
+  const { error } = await deleteItem(itemId, authResult.accessToken)
+  if (error) {
+    return {
+      error: `Failed to delete item: ${error}.`
+    }
+  }
+
+  updateTag('items')
+  updateTag(`item-${itemId}`)
+
+  return { success: 'Item deleted successfully.' }
+}

--- a/learn_nextjs/src/actions/user/actions.ts
+++ b/learn_nextjs/src/actions/user/actions.ts
@@ -14,8 +14,8 @@ import {
   updateItem
 } from '@/app/api/server-endpoints'
 import type { PatchItemRequest } from '@/app/api/types'
+import type { MeActionState } from '@/app/me/types'
 import { itemPatchFormSchema } from '@/schemas/items/forms'
-import type { MeActionState } from '@/types/me/types'
 
 const profileEmailSchema = z.object({
   email: z.email({

--- a/learn_nextjs/src/app/(auth)/AuthForm.tsx
+++ b/learn_nextjs/src/app/(auth)/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import {
-  type FormEvent,
+  type SubmitEvent,
   startTransition,
   useActionState,
   useState
@@ -33,7 +33,7 @@ export const AuthForm = ({
   const [password, setPassword] = useState('')
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault()
     setFieldErrors({})
 

--- a/learn_nextjs/src/app/api/[...path]/route.ts
+++ b/learn_nextjs/src/app/api/[...path]/route.ts
@@ -1,9 +1,9 @@
 import { cookies } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
-
 import { API_BASE_URL as BACKEND_URL } from '@/common/const'
-import { TokenV2Schema } from '@/common/schemas/api/resources'
+import { TokenSchema } from '@/common/schemas/api/resources'
 import type { PromisePathProps } from '@/types/api/types'
+import { refreshAccessToken } from '../server-endpoints'
 
 const handler = async (
   request: NextRequest,
@@ -14,6 +14,52 @@ const handler = async (
 
   const cookieStore = await cookies()
   const accessToken = cookieStore.get('access_token')?.value
+
+  const isRefresh = apiPath === 'auth/refresh'
+
+  if (isRefresh) {
+    const csrfToken = cookieStore.get('csrf_token')?.value
+    const refreshToken = cookieStore.get('refresh_token')?.value
+
+    if (!csrfToken || !refreshToken)
+      return NextResponse.redirect(
+        new URL('/login?reason=user_not_authenticated', request.url)
+      )
+
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      Cookie: `csrf_token=${csrfToken};refresh_token=${refreshToken}`,
+      'X-CSRF-Token': csrfToken
+    })
+
+    const rawData = await refreshAccessToken(headers)
+    if (!rawData.data && rawData.error) {
+      return NextResponse.redirect(
+        new URL('/login?reason=session_expired', request.url)
+      )
+    }
+
+    const { data, error, success } = TokenSchema.safeParse(rawData)
+    if (!success || error) {
+      return NextResponse.redirect(
+        new URL('/login?reason=refresh_failed', request.url)
+      )
+    }
+
+    const response = NextResponse.json({ refreshed: true })
+
+    const { access_token: accessToken, expires_in: accessExpiresIn } = data
+    response.cookies.set('access_token', accessToken, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      expires: new Date(Date.now() + accessExpiresIn * 1000),
+      secure: process.env.ENVIRONMENT === 'production'
+    })
+
+    return response
+  }
+
   const refreshToken = cookieStore.get('refresh_token')?.value
   const forwardHeaders = new Headers()
 
@@ -21,11 +67,12 @@ const handler = async (
     'Content-Type',
     request.headers.get('Content-Type') ?? 'application/json'
   )
+
   if (accessToken) {
     forwardHeaders.set('Authorization', `Bearer ${accessToken}`)
   }
-  const isRefreshEndpoint = apiPath === 'auth/refresh'
-  if (refreshToken && isRefreshEndpoint) {
+
+  if (refreshToken && isRefresh) {
     forwardHeaders.set('X-Refresh-Token', refreshToken)
   }
 
@@ -43,60 +90,6 @@ const handler = async (
           backendRes.headers.get('Content-Type') ?? 'application/json'
       }
     })
-  }
-
-  const isLogin = apiPath === 'auth/token'
-  const isLogout = apiPath === 'auth/logout'
-
-  if (isLogin) {
-    const rawData: unknown = await backendRes.json()
-    const { data, error, success } = TokenV2Schema.safeParse(rawData)
-    if (!success || error) {
-      return NextResponse.json(
-        {
-          detail: `Invalid login response: ${error?.message ?? 'Unknown error'}`
-        },
-        { status: 502 }
-      )
-    }
-
-    const response = NextResponse.json({ loggedIn: true })
-
-    const {
-      access_token: accessToken,
-      refresh_token: refreshToken,
-      access_expires_in: accessExpiresIn,
-      refresh_expires_in: refreshExpiresIn
-    } = data
-    response.cookies.set('access_token', accessToken, {
-      httpOnly: true,
-      sameSite: 'lax',
-      path: '/',
-      expires: new Date(Date.now() + accessExpiresIn * 1000),
-      secure: process.env.ENVIRONMENT === 'production'
-    })
-    response.cookies.set('refresh_token', refreshToken, {
-      httpOnly: true,
-      sameSite: 'lax',
-      path: '/',
-      expires: new Date(Date.now() + refreshExpiresIn * 1000),
-      secure: process.env.ENVIRONMENT === 'production'
-    })
-
-    return response
-  }
-  if (isLogout) {
-    if (backendRes.status !== 204) {
-      return NextResponse.json(
-        { detail: 'Invalid logout response' },
-        { status: 502 }
-      )
-    }
-
-    const response = NextResponse.json({ loggedOut: true })
-    response.cookies.delete('access_token')
-    response.cookies.delete('refresh_token')
-    return response
   }
 
   const body = await backendRes.text()

--- a/learn_nextjs/src/app/api/abstraction.ts
+++ b/learn_nextjs/src/app/api/abstraction.ts
@@ -4,9 +4,24 @@
 import { NEXT_API_PROXY_PREFIX } from '@/common/const'
 import type {
   APIBaseProps,
+  ApiCallInit,
   ApiProxyResponse,
+  BuildHeadersOptions,
   RequestFactoryOptions
 } from '@/types/api/types'
+
+const buildHeaders = (options: BuildHeadersOptions) => {
+  const { auth, hasBody, isSerializedBody } = options
+  const headers = new Headers(options.headers)
+
+  if (hasBody && !isSerializedBody && !headers.has('Content-Type'))
+    headers.set('Content-Type', 'application/json')
+  if (auth?.accessToken)
+    headers.set('Authorization', `Bearer ${auth.accessToken}`)
+  if (auth?.csrfToken) headers.set('X-CSRF-Token', auth.csrfToken)
+
+  return headers
+}
 
 const getProxyBase = (): string => {
   // En el servidor (Server Components), fetch necesita URL absoluta
@@ -37,24 +52,23 @@ const apiRequest = async <T>(
     method = 'GET',
     pathParam = null,
     body,
-    accessToken = null,
     headers = {},
     queryParams,
     apiVersion = '/latest',
-    credentials = 'include'
+    credentials = 'include',
+    auth
   } = options
 
   const hasBody = body !== undefined
   const isSerializedBody =
     body instanceof URLSearchParams || body instanceof FormData
 
-  const requestHeaders: HeadersInit = {
-    ...(hasBody && !isSerializedBody
-      ? { 'Content-Type': 'application/json' }
-      : {}),
-    ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-    ...headers
-  }
+  const requestHeaders = buildHeaders({
+    auth,
+    hasBody,
+    isSerializedBody,
+    headers
+  })
   const baseUrl = buildUrl({ endpoint, pathParam, apiVersion }, queryParams)
   const response = await fetch(baseUrl, {
     method,
@@ -89,56 +103,78 @@ const apiRequest = async <T>(
 }
 
 export const api = {
-  get: <T>(options: APIBaseProps, queryParams?: Record<string, string>) => {
-    const { endpoint, pathParam, accessToken, apiVersion } = options
+  get: <T>(options: APIBaseProps, init?: ApiCallInit) => {
+    const { endpoint, pathParam, apiVersion } = options
+    const { auth, credentials, headers, queryParams } = init ?? {}
     return apiRequest<T>(endpoint, {
       method: 'GET',
       pathParam,
-      accessToken,
+      headers,
+      auth,
+      credentials,
       queryParams,
       apiVersion
     })
   },
   post: <T, B = unknown>(
-    options: APIBaseProps & { credentials?: RequestCredentials },
-    body?: B
+    options: APIBaseProps & {
+      credentials?: RequestCredentials
+    },
+    body?: B,
+    init?: ApiCallInit
   ) => {
-    const { endpoint, accessToken, apiVersion, credentials } = options
+    const { endpoint, apiVersion } = options
+    const { auth, credentials, headers, queryParams } = init ?? {}
     return apiRequest<T>(endpoint, {
       method: 'POST',
       body,
-      accessToken,
       apiVersion,
-      credentials
+      headers,
+      credentials,
+      auth,
+      queryParams
     })
   },
-  put: <T, B = unknown>(options: APIBaseProps, body: B) => {
-    const { endpoint, pathParam, accessToken, apiVersion } = options
+  put: <T, B = unknown>(options: APIBaseProps, body?: B, init?: ApiCallInit) => {
+    const { endpoint, apiVersion } = options
+    const { auth, credentials, headers, queryParams } = init ?? {}
     return apiRequest<T>(endpoint, {
       method: 'PUT',
       body,
-      pathParam,
-      accessToken,
-      apiVersion
+      apiVersion,
+      headers,
+      credentials,
+      auth,
+      queryParams
     })
   },
-  patch: <T, B = unknown>(options: APIBaseProps, body: B) => {
-    const { endpoint, pathParam, accessToken, apiVersion } = options
+  patch: <T, B = unknown>(
+    options: APIBaseProps,
+    body?: B,
+    init?: ApiCallInit
+  ) => {
+    const { endpoint, apiVersion } = options
+    const { auth, credentials, headers, queryParams } = init ?? {}
     return apiRequest<T>(endpoint, {
-      method: 'PATCH',
+      method: 'PUT',
       body,
-      pathParam,
-      accessToken,
-      apiVersion
+      apiVersion,
+      headers,
+      credentials,
+      auth,
+      queryParams
     })
   },
-  delete: <T>(options: APIBaseProps) => {
-    const { endpoint, pathParam, accessToken, apiVersion } = options
+  delete: <T>(options: APIBaseProps, init?: ApiCallInit) => {
+    const { endpoint, apiVersion } = options
+    const { auth, credentials, headers, queryParams } = init ?? {}
     return apiRequest<T>(endpoint, {
       method: 'DELETE',
-      pathParam,
-      accessToken,
-      apiVersion
+      apiVersion,
+      headers,
+      credentials,
+      auth,
+      queryParams
     })
   }
 }

--- a/learn_nextjs/src/app/api/abstraction.ts
+++ b/learn_nextjs/src/app/api/abstraction.ts
@@ -135,7 +135,11 @@ export const api = {
       queryParams
     })
   },
-  put: <T, B = unknown>(options: APIBaseProps, body?: B, init?: ApiCallInit) => {
+  put: <T, B = unknown>(
+    options: APIBaseProps,
+    body?: B,
+    init?: ApiCallInit
+  ) => {
     const { endpoint, apiVersion } = options
     const { auth, credentials, headers, queryParams } = init ?? {}
     return apiRequest<T>(endpoint, {

--- a/learn_nextjs/src/app/api/endpoints.ts
+++ b/learn_nextjs/src/app/api/endpoints.ts
@@ -24,20 +24,40 @@ export const getItem = async (id: string) => {
   return api.get<Item>({ endpoint: ITEMS_PATH, pathParam: id })
 }
 
-export const createItem = async (item: CreateItemRequest) => {
-  return api.post<Item>({ endpoint: ITEMS_PATH }, item)
+export const createItem = async (
+  item: CreateItemRequest,
+  accessToken: string
+) => {
+  return api.post<Item>({ endpoint: ITEMS_PATH }, item, {
+    auth: { accessToken }
+  })
 }
 
-export const updateItem = async (id: string, item: CreateItemRequest) => {
-  return api.put<Item>({ endpoint: ITEMS_PATH, pathParam: id }, item)
+export const updateItem = async (
+  id: string,
+  item: CreateItemRequest,
+  accessToken: string
+) => {
+  return api.put<Item>({ endpoint: ITEMS_PATH, pathParam: id }, item, {
+    auth: { accessToken }
+  })
 }
 
-export const patchItem = async (id: string, item: CreateItemRequest) => {
-  return api.patch<Item>({ endpoint: ITEMS_PATH, pathParam: id }, item)
+export const patchItem = async (
+  id: string,
+  item: CreateItemRequest,
+  accessToken: string
+) => {
+  return api.patch<Item>({ endpoint: ITEMS_PATH, pathParam: id }, item, {
+    auth: { accessToken }
+  })
 }
 
-export const deleteItem = async (id: string) => {
-  return api.delete({ endpoint: ITEMS_PATH, pathParam: id })
+export const deleteItem = async (id: string, accessToken: string) => {
+  return api.delete(
+    { endpoint: ITEMS_PATH, pathParam: id },
+    { auth: { accessToken } }
+  )
 }
 
 export const getItemImage = async (filename: string) => {
@@ -137,41 +157,39 @@ export const deleteUser = async (id: string) => {
 
 // ==================  AUTH  ==================
 const AUTH_PATH = '/auth'
-
-// ==================   (Versioned)   ==================
-export const register = async (
-  email: string,
-  password: string,
-  apiVersion?: ApiVersion
-) => {
+export const register = async (email: string, password: string) => {
   return api.post<User>(
-    { endpoint: `${AUTH_PATH}/register`, apiVersion },
+    { endpoint: `${AUTH_PATH}/register` },
     { email, password }
   )
 }
 
-export const login = async (
-  email: string,
-  password: string,
-  apiVersion?: ApiVersion
-) => {
-  const body = new URLSearchParams({ username: email, password })
-  return api.post<ApiProxyLoginResponse>(
-    { endpoint: `${AUTH_PATH}/token`, apiVersion },
-    body
+export const refreshAccessToken = async (csrfToken: string) => {
+  return api.post<Token>(
+    { endpoint: `${AUTH_PATH}/refresh`, credentials: 'include' },
+    {},
+    { auth: { csrfToken } }
   )
 }
 
-export const refreshToken = async (apiVersion?: ApiVersion) => {
-  return api.post<Token>(
-    { endpoint: `${AUTH_PATH}/refresh`, apiVersion, credentials: 'include' },
+export const logout = async () => {
+  return api.post<ApiProxyLogoutResponse>(
+    { endpoint: `${AUTH_PATH}/logout` },
     {}
   )
 }
 
-export const logout = async (apiVersion?: ApiVersion) => {
-  return api.post<ApiProxyLogoutResponse>(
-    { endpoint: `${AUTH_PATH}/logout`, apiVersion },
+// ==================   (Versioned)   ==================
+
+export const login = async (
+  email: string,
+  password: string,
+  apiVersion: ApiVersion
+) => {
+  const body = new URLSearchParams({ username: email, password })
+  return api.post<ApiProxyLoginResponse>(
+    { endpoint: `${AUTH_PATH}/token`, apiVersion },
+    body,
     {}
   )
 }

--- a/learn_nextjs/src/app/api/server-endpoints.ts
+++ b/learn_nextjs/src/app/api/server-endpoints.ts
@@ -3,68 +3,119 @@ import type {
   Items,
   Token,
   TokenV2,
-  User
+  User,
+  UserUpdate
 } from '@/common/types/api/resources'
 import 'server-only'
-import { serverGet, serverPost } from './server-fetch'
-import type { AuthProps, CreateItemRequest } from './types'
+import { serverDelete, serverGet, serverPost, serverPut } from './server-fetch'
+import type { AuthProps, CreateItemRequest, PatchItemRequest } from './types'
+
+const API_PREFIX = '/latest'
 
 // ==================  ITEMS  ==================
-export const getItems = async () => await serverGet<Items>('/latest/items/')
+const ITEMS_BASE_PATH = `${API_PREFIX}/items/`
+
+export const getItems = async () => await serverGet<Items>(`${ITEMS_BASE_PATH}`)
+
 export const getItem = async (id: string) =>
-  await serverGet<Item>(`/latest/items/${id}`)
+  await serverGet<Item>(`${ITEMS_BASE_PATH}${id}`)
+
 export const createItem = async (
   item: CreateItemRequest,
   accessToken: string
-) => await serverPost<Item>('/latest/items/', item, accessToken)
+) => await serverPost<Item>(`${ITEMS_BASE_PATH}`, item, accessToken)
 
-// export const updateItem = async (id: string, item: CreateItemRequest) =>
-//   await serverPut(`/latest/items/${id}`, item)
+export const updateItem = async (
+  id: string,
+  item: PatchItemRequest,
+  accessToken: string
+) => await serverPut<Item>(`${ITEMS_BASE_PATH}${id}`, item, accessToken)
 
-// export const deleteItem = async (id: string) => await serverDelete(`/latest/items/${id}`)
+export const deleteItem = async (id: string, accessToken: string) =>
+  await serverDelete(`${ITEMS_BASE_PATH}${id}`, accessToken)
 
 // export const getItemImage = async (filename: string) =>
-//   await serverGet(`/latest/items/image/?filename=${encodeURIComponent(filename)}`)
+//   await serverGet(`${ITEMS_BASE_PATH}image/?filename=${encodeURIComponent(filename)}`)
 
 // export const uploadImageForItem = async (id: string, imageFile: File) => {
 //   const formData = new FormData()
 //   formData.append('image', imageFile)
-//   return await serverPost(`/latest/items/image/${id}`, formData)
+//   return await serverPost(`${ITEMS_BASE_PATH}image/${id}`, formData)
 // }
 
+export const getOwnerItems = async (userId?: string, accessToken?: string) => {
+  return await serverGet<Items>(
+    `${ITEMS_BASE_PATH}owner/${userId ? `?order_id=${userId}` : ''}`,
+    accessToken
+  )
+}
+
+export const getOwnerItem = async (
+  itemId: string,
+  userId?: string,
+  accessToken?: string
+) => {
+  return await serverGet<Item>(
+    `${ITEMS_BASE_PATH}/order/${itemId}${userId ? `?order_id=${userId}` : ''}`,
+    accessToken
+  )
+}
+
 // ==================  AUTH  ==================
+const AUTH_BASE_PATH = `${API_PREFIX}/auth/`
+
 export const login = async (body: URLSearchParams) => {
-  return await serverPost<TokenV2>('/latest/auth/token', body, undefined, {
+  return await serverPost<TokenV2>(`${AUTH_BASE_PATH}token`, body, undefined, {
     'Content-Type': 'application/x-www-form-urlencoded'
   })
 }
+
 export const signup = async ({ email, password }: AuthProps) => {
-  return await serverPost<User>('/latest/auth/register', { email, password })
+  return await serverPost<User>(`${AUTH_BASE_PATH}register`, {
+    email,
+    password
+  })
 }
+
 export const logout = async (accessToken: string) => {
-  return await serverPost<null>('/latest/auth/logout', {}, accessToken)
+  return await serverPost<null>(`${AUTH_BASE_PATH}logout`, {}, accessToken)
 }
-export const refreshToken = async () => {
-  return await serverPost<Token>('/latest/auth/refresh', {})
+
+export const refreshAccessToken = async (headers: Headers) => {
+  return await serverPost<Token>(
+    `${AUTH_BASE_PATH}refresh`,
+    {},
+    undefined,
+    headers
+  )
 }
 
 // ==================  USER  ==================
+const USER_BASE_PATH = `${API_PREFIX}/users/`
+
 export const getMe = async (accessToken: string) => {
-  return await serverGet<User>('/latest/users/me', accessToken)
+  return await serverGet<User>(`${USER_BASE_PATH}me`, accessToken)
 }
 
-// export const updateCurrentUser = async (userUpdate: UserUpdate) => {
-//   return await serverPut('/latest/users/me', userUpdate)
-// }
+export const updateCurrentUser = async (
+  accessToken: string,
+  userUpdate: UserUpdate
+) => {
+  return await serverPut<User>(`${USER_BASE_PATH}me`, userUpdate, accessToken)
+}
+
+export const deleteCurrentUser = async (accessToken: string) => {
+  return await serverDelete<null>(`${USER_BASE_PATH}me`, accessToken)
+}
 
 // export const changePassword = async (passwordData: PasswordChangeRequest) => {
-//   return await serverPost('/latest/users/me/password', passwordData)
+//   return await serverPost(`${USER_BASE_PATH}me/password`, passwordData)
 // }
 
 // export const requestPasswordReset = async (email: string) => {
-//   return await serverPost('/latest/auth/request-password-reset', { email })
+//   return await serverPost(`${USER_BASE_PATH}request-password-reset`, { email })
 // }
 
 // export const resetPassword = async (resetData: PasswordResetRequest) => {
-//   return await serverPost('/latest/auth/reset-password', resetData)
+//   return await serverPost(`${USER_BASE_PATH}reset-password`, resetData)
 // }

--- a/learn_nextjs/src/app/api/types.ts
+++ b/learn_nextjs/src/app/api/types.ts
@@ -2,6 +2,8 @@ import type { Item } from '../../common/types/api/resources'
 
 export type CreateItemRequest = Omit<Item, 'id'>
 
+export type PatchItemRequest = Partial<CreateItemRequest>
+
 export interface AuthProps {
   email: string
   password: string

--- a/learn_nextjs/src/app/auth-provider.tsx
+++ b/learn_nextjs/src/app/auth-provider.tsx
@@ -29,12 +29,15 @@ export const AuthProvider = ({ children }: Children) => {
     const { data, error } = await getMe()
 
     if (!data || error) {
-      const csrfToken = document.cookie.split('; ').find((cookie) => cookie.startsWith('csrf_token='))
+      const csrfToken = document.cookie
+        .split('; ')
+        .find((cookie) => cookie.startsWith('csrf_token='))
       if (!csrfToken) return { status: 'unauthenticated' }
-      
+
       const refreshResult = await refreshAccessToken(csrfToken)
 
-      if (refreshResult.error || !refreshResult.data) return { status: 'unauthenticated' }
+      if (refreshResult.error || !refreshResult.data)
+        return { status: 'unauthenticated' }
 
       return checkAuth()
     }

--- a/learn_nextjs/src/app/auth-provider.tsx
+++ b/learn_nextjs/src/app/auth-provider.tsx
@@ -1,12 +1,10 @@
 'use client'
 
 import { createContext, useCallback, useEffect, useReducer } from 'react'
-
 import { UserSchema } from '@/common/schemas/api/resources'
 import type { User } from '@/common/types/api/resources'
 import type { Children } from '@/common/types/layout'
-
-import { getMe } from './api/endpoints'
+import { getMe, refreshAccessToken } from './api/endpoints'
 
 type AuthState =
   | { status: 'loading' }
@@ -31,7 +29,14 @@ export const AuthProvider = ({ children }: Children) => {
     const { data, error } = await getMe()
 
     if (!data || error) {
-      return { status: 'unauthenticated' }
+      const csrfToken = document.cookie.split('; ').find((cookie) => cookie.startsWith('csrf_token='))
+      if (!csrfToken) return { status: 'unauthenticated' }
+      
+      const refreshResult = await refreshAccessToken(csrfToken)
+
+      if (refreshResult.error || !refreshResult.data) return { status: 'unauthenticated' }
+
+      return checkAuth()
     }
 
     const user = UserSchema.safeParse(data)

--- a/learn_nextjs/src/app/components/NavBar.tsx
+++ b/learn_nextjs/src/app/components/NavBar.tsx
@@ -61,6 +61,16 @@ export const NavBar = () => {
                   }
                   nativeButton={false}
                 />
+                {isLoggedIn && (
+                  <SheetClose
+                    render={
+                      <Link className="text-lg font-semibold" href="/me">
+                        My Account
+                      </Link>
+                    }
+                    nativeButton={false}
+                  />
+                )}
                 <SheetClose
                   render={
                     <Link className="text-lg font-semibold" href="/about">
@@ -88,6 +98,13 @@ export const NavBar = () => {
                 Items
               </Link>
             </li>
+            {isLoggedIn && (
+              <li>
+                <Link className="text-lg font-semibold" href="/me">
+                  My Account
+                </Link>
+              </li>
+            )}
             <li>
               <Link className="text-lg font-semibold" href="/about">
                 About

--- a/learn_nextjs/src/app/items/[id]/page.tsx
+++ b/learn_nextjs/src/app/items/[id]/page.tsx
@@ -1,10 +1,10 @@
 import { CreditCardIcon, ShoppingCartIcon, Star, StarHalf } from 'lucide-react'
 import { cacheTag } from 'next/cache'
 import Image from 'next/image'
+import { getItem } from '@/api/server-endpoints'
 import { NO_IMAGE_AVAILABLE_URL } from '@/common/const'
 import type { PromiseIdProp } from '@/common/types/routing'
 import { Button } from '@/components/ui/button'
-import { getItem } from '../../api/server-endpoints'
 import { RetryCard } from '../RetryCard'
 
 const ItemPage = async ({ params }: PromiseIdProp) => {
@@ -22,51 +22,45 @@ const ItemPage = async ({ params }: PromiseIdProp) => {
       />
     )
 
+  if (!item) return null
+
   return (
     <div>
       <div>
-        {item && (
-          <>
-            <div className="border border-border rounded-2xl overflow-hidden">
-              <Image
-                src={NO_IMAGE_AVAILABLE_URL}
-                alt={item.description}
-                className="block size-full object-cover object-center"
-                width={500}
-                height={500}
-                loading="eager"
-              />
-            </div>
-            <div className="flex my-4">
-              <div className="flex *:size-5 *:border-[#c9a74d] items-center *:stroke-1">
-                <Star fill="#c9a74d" color="#c9a74d" />
-                <Star fill="#c9a74d" color="#c9a74d" />
-                <Star fill="#c9a74d" color="#c9a74d" />
-                <Star fill="#c9a74d" color="#c9a74d" />
-                <Star className="relative" color="#c9a74d">
-                  <StarHalf
-                    fill="#c9a74d"
-                    color="#c9a74d"
-                    className="absolute"
-                  />
-                </Star>
-              </div>
-              <span className="ml-2">4.8</span>
-              <span className="ml-1">(124 reviews)</span>
-            </div>
-            <h1 className="mb-6 text-3xl font-bold">{item.name}</h1>
-            <p className="mb-5 text-2xl font-bold">
-              {/* Round total price (item.price + item.tax) */}${' '}
-              {Math.round((item.price + item.tax) * 100) / 100}{' '}
-              <span className="text-sm font-normal text-muted-foreground">
-                (Tax included: $ {Math.round(item.tax * 100) / 100})
-              </span>
-            </p>
-            <p className="mb-5 text-xl font-bold">
-              <span className="font-normal">{item.description}</span>
-            </p>
-          </>
-        )}
+        <div className="border border-border rounded-2xl overflow-hidden">
+          <Image
+            src={NO_IMAGE_AVAILABLE_URL}
+            alt={item.description}
+            className="block size-full object-cover object-center"
+            width={500}
+            height={500}
+            loading="eager"
+          />
+        </div>
+        <div className="flex my-4">
+          <div className="flex *:size-5 *:border-[#c9a74d] items-center *:stroke-1">
+            <Star fill="#c9a74d" color="#c9a74d" />
+            <Star fill="#c9a74d" color="#c9a74d" />
+            <Star fill="#c9a74d" color="#c9a74d" />
+            <Star fill="#c9a74d" color="#c9a74d" />
+            <Star className="relative" color="#c9a74d">
+              <StarHalf fill="#c9a74d" color="#c9a74d" className="absolute" />
+            </Star>
+          </div>
+          <span className="ml-2">4.8</span>
+          <span className="ml-1">(124 reviews)</span>
+        </div>
+        <h1 className="mb-6 text-3xl font-bold">{item.name}</h1>
+        <p className="mb-5 text-2xl font-bold">
+          {/* Round total price (item.price + item.tax) */}${' '}
+          {Math.round((item.price + item.tax) * 100) / 100}{' '}
+          <span className="text-sm font-normal text-muted-foreground">
+            (Tax included: $ {Math.round(item.tax * 100) / 100})
+          </span>
+        </p>
+        <p className="mb-5 text-xl font-bold">
+          <span className="font-normal">{item.description}</span>
+        </p>
       </div>
       <div className="mt-15">
         <div className="flex flex-col gap-4 *:py-2 *:h-12 *:items-center">

--- a/learn_nextjs/src/app/me/ActionFeedback.tsx
+++ b/learn_nextjs/src/app/me/ActionFeedback.tsx
@@ -1,0 +1,15 @@
+import type { ActionFeedbackProps } from './types'
+
+export const ActionFeedback = ({ state }: ActionFeedbackProps) => {
+  if (!state) return null
+
+  return (
+    <p
+      className={`text-sm ${state.error ? 'text-destructive' : 'text-green-700'}`}
+      role="status"
+      aria-live="polite"
+    >
+      {state.error ?? state.success}
+    </p>
+  )
+}

--- a/learn_nextjs/src/app/me/MePageClient.tsx
+++ b/learn_nextjs/src/app/me/MePageClient.tsx
@@ -1,0 +1,349 @@
+'use client'
+
+import Link from 'next/link'
+import { useActionState, useState } from 'react'
+
+import {
+  deleteAccountAction,
+  deleteOwnedItemAction,
+  updateOwnedItemAction,
+  updateProfileEmailAction,
+  updateProfilePasswordAction
+} from '@/actions/user/actions'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { ActionFeedback } from './ActionFeedback'
+import type { MePageClientProps, OwnedItemEditorProps } from './types'
+
+const OwnedItemEditor = ({ item }: OwnedItemEditorProps) => {
+  const [state, formAction, isPending] = useActionState(
+    updateOwnedItemAction,
+    null
+  )
+  const [deleteState, deleteFormAction, isDeletePending] = useActionState(
+    deleteOwnedItemAction,
+    null
+  )
+
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex flex-wrap items-center gap-2 text-lg">
+          <span>{item.name}</span>
+          <Badge>${item.price.toFixed(2)}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form action={formAction} className="space-y-4" noValidate>
+          <input type="hidden" name="itemId" value={item.id} readOnly />
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor={`name-${item.id}`}>Name</FieldLabel>
+              <Input
+                id={`name-${item.id}`}
+                name="name"
+                defaultValue={item.name}
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor={`description-${item.id}`}>
+                Description
+              </FieldLabel>
+              <Textarea
+                id={`description-${item.id}`}
+                name="description"
+                defaultValue={item.description}
+              />
+            </Field>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Field>
+                <FieldLabel htmlFor={`price-${item.id}`}>Price</FieldLabel>
+                <Input
+                  id={`price-${item.id}`}
+                  name="price"
+                  type="number"
+                  step="0.01"
+                  defaultValue={item.price}
+                />
+              </Field>
+              <Field>
+                <FieldLabel htmlFor={`tax-${item.id}`}>Tax</FieldLabel>
+                <Input
+                  id={`tax-${item.id}`}
+                  name="tax"
+                  type="number"
+                  step="0.01"
+                  defaultValue={item.tax}
+                />
+              </Field>
+            </div>
+            <Field>
+              <FieldLabel htmlFor={`imageUrl-${item.id}`}>Image URL</FieldLabel>
+              <Input
+                id={`imageUrl-${item.id}`}
+                name="imageUrl"
+                defaultValue={item.image_url ?? ''}
+              />
+            </Field>
+          </FieldGroup>
+
+          <ActionFeedback state={state} />
+
+          <Button type="submit" disabled={isPending} className="cursor-pointer">
+            {isPending ? 'Saving...' : 'Save Changes'}
+          </Button>
+        </form>
+
+        <form action={deleteFormAction}>
+          <input type="hidden" name="itemId" value={item.id} readOnly />
+          <ActionFeedback state={deleteState} />
+          <Button
+            type="submit"
+            variant="destructive"
+            disabled={isDeletePending}
+            className="mt-3 cursor-pointer"
+          >
+            {isDeletePending ? 'Deleting...' : 'Delete Item'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+export const MePageClient = ({ user, ownedItems }: MePageClientProps) => {
+  const [activeTab, setActiveTab] = useState<'profile' | 'items'>('profile')
+
+  const [emailState, emailFormAction, isEmailPending] = useActionState(
+    updateProfileEmailAction,
+    null
+  )
+  const [passwordState, passwordFormAction, isPasswordPending] = useActionState(
+    updateProfilePasswordAction,
+    null
+  )
+  const [deleteState, deleteFormAction, isDeletePending] = useActionState(
+    deleteAccountAction,
+    null
+  )
+
+  return (
+    <section className="mx-auto w-full max-w-4xl space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">My Account</h1>
+        <p className="text-muted-foreground">
+          Manage your profile settings and only your own items.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant={activeTab === 'profile' ? 'default' : 'outline'}
+          onClick={() => setActiveTab('profile')}
+          className="cursor-pointer"
+        >
+          Profile
+        </Button>
+        <Button
+          type="button"
+          variant={activeTab === 'items' ? 'default' : 'outline'}
+          onClick={() => setActiveTab('items')}
+          className="cursor-pointer"
+        >
+          My Items ({ownedItems.length})
+        </Button>
+      </div>
+
+      {activeTab === 'profile' && (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Account Overview</CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-3 text-sm">
+              <p>
+                <strong>Email:</strong> {user.email}
+              </p>
+              <p>
+                <strong>Role:</strong>{' '}
+                {user.is_superuser ? 'Superuser' : 'User'}
+              </p>
+              <p>
+                <strong>Status:</strong>{' '}
+                {user.is_active ? 'Active' : 'Inactive'}
+              </p>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Update Email</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form action={emailFormAction} className="space-y-4" noValidate>
+                <FieldGroup>
+                  <Field>
+                    <FieldLabel htmlFor="email">New Email</FieldLabel>
+                    <Input id="email" name="email" type="email" required />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="currentPasswordForEmail">
+                      Current Password
+                    </FieldLabel>
+                    <Input
+                      id="currentPasswordForEmail"
+                      name="currentPassword"
+                      type="password"
+                      required
+                    />
+                  </Field>
+                </FieldGroup>
+
+                <ActionFeedback state={emailState} />
+
+                <Button
+                  type="submit"
+                  disabled={isEmailPending}
+                  className="cursor-pointer"
+                >
+                  {isEmailPending ? 'Updating...' : 'Update Email'}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Update Password</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form
+                action={passwordFormAction}
+                className="space-y-4"
+                noValidate
+              >
+                <FieldGroup>
+                  <Field>
+                    <FieldLabel htmlFor="currentPasswordForPassword">
+                      Current Password
+                    </FieldLabel>
+                    <Input
+                      id="currentPasswordForPassword"
+                      name="currentPassword"
+                      type="password"
+                      required
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="newPassword">New Password</FieldLabel>
+                    <Input
+                      id="newPassword"
+                      name="newPassword"
+                      type="password"
+                      required
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="confirmPassword">
+                      Confirm New Password
+                    </FieldLabel>
+                    <Input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      required
+                    />
+                  </Field>
+                </FieldGroup>
+
+                <ActionFeedback state={passwordState} />
+
+                <Button
+                  type="submit"
+                  disabled={isPasswordPending}
+                  className="cursor-pointer"
+                >
+                  {isPasswordPending ? 'Updating...' : 'Update Password'}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+
+          <Card className="border-red-200">
+            <CardHeader>
+              <CardTitle className="text-destructive">Delete Account</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form action={deleteFormAction} className="space-y-4" noValidate>
+                <Field>
+                  <FieldLabel htmlFor="confirmDelete">
+                    Type DELETE to confirm
+                  </FieldLabel>
+                  <Input id="confirmDelete" name="confirmDelete" required />
+                  <FieldError>This action is irreversible.</FieldError>
+                </Field>
+
+                <ActionFeedback state={deleteState} />
+
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  disabled={isDeletePending}
+                  className="cursor-pointer"
+                >
+                  {isDeletePending ? 'Deleting...' : 'Delete My Account'}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {activeTab === 'items' && (
+        <div className="space-y-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-2xl font-semibold">My Items</h2>
+            <Link
+              href="/items/new"
+              className="border-primary text-primary hover:bg-primary rounded-md border px-4 py-2 font-semibold transition-colors hover:text-white"
+            >
+              Create Item
+            </Link>
+          </div>
+
+          {ownedItems.length === 0 && (
+            <Card>
+              <CardContent className="space-y-3 py-6">
+                <p className="text-muted-foreground">
+                  You have not created any items yet.
+                </p>
+                <Link
+                  href="/items/new"
+                  className="text-primary inline-block font-semibold underline"
+                >
+                  Create your first item
+                </Link>
+              </CardContent>
+            </Card>
+          )}
+
+          <div className="grid gap-4">
+            {ownedItems.map((item) => (
+              <OwnedItemEditor key={item.id} item={item} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/learn_nextjs/src/app/me/page.tsx
+++ b/learn_nextjs/src/app/me/page.tsx
@@ -1,0 +1,38 @@
+import { cookies } from 'next/headers'
+import { redirect } from 'next/navigation'
+
+import { getMe, getOwnerItems } from '@/app/api/server-endpoints'
+import { RetryCard } from '@/app/items/RetryCard'
+import { MePageClient } from './MePageClient'
+
+const MePage = async () => {
+  const accessToken = (await cookies()).get('access_token')?.value
+
+  if (!accessToken) {
+    redirect('/login?next=%2Fme')
+  }
+
+  const { data: me, error: meError } = await getMe(accessToken)
+  if (meError || !me) {
+    redirect('/login?next=%2Fme')
+  }
+
+  const { data: ownedItems, error: itemsError } = await getOwnerItems(
+    me.id,
+    accessToken
+  )
+
+  if (itemsError || !ownedItems) {
+    return (
+      <RetryCard
+        cardTitle="My Account"
+        error={itemsError ?? 'Failed to load your items. Please try again.'}
+        tagToUpdate="items"
+      />
+    )
+  }
+
+  return <MePageClient user={me} ownedItems={ownedItems} />
+}
+
+export default MePage

--- a/learn_nextjs/src/app/me/types.ts
+++ b/learn_nextjs/src/app/me/types.ts
@@ -1,0 +1,19 @@
+import type { Item, Items, User } from '@/common/types/api/resources'
+
+type MeActionState = {
+  error?: string
+  success?: string
+} | null
+
+export type MePageClientProps = {
+  user: User
+  ownedItems: Items
+}
+
+export interface ActionFeedbackProps {
+  state: MeActionState
+}
+
+export interface OwnedItemEditorProps {
+  item: Item
+}

--- a/learn_nextjs/src/app/me/types.ts
+++ b/learn_nextjs/src/app/me/types.ts
@@ -1,6 +1,6 @@
 import type { Item, Items, User } from '@/common/types/api/resources'
 
-type MeActionState = {
+export type MeActionState = {
   error?: string
   success?: string
 } | null

--- a/learn_nextjs/src/common/schemas/api/resources.ts
+++ b/learn_nextjs/src/common/schemas/api/resources.ts
@@ -17,6 +17,15 @@ export const ItemSchema = z.object({
   image_url: z.string().optional()
 })
 
+export const ItemPatchSchema = z.object({
+  user_id: z.string().optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  price: z.number().nonnegative().gte(0).optional(),
+  tax: z.number().nonnegative().gte(0).optional(),
+  image_url: z.string().optional()
+})
+
 export const UserSchema = z.object({
   id: z.string(),
   email: z.email({

--- a/learn_nextjs/src/proxy.ts
+++ b/learn_nextjs/src/proxy.ts
@@ -25,10 +25,18 @@ export const proxy = async (request: NextRequest) => {
         request.nextUrl.pathname + request.nextUrl.search
       )
 
-      if (!request.cookies.has('refresh_token'))
+      const refreshToken = request.cookies.get('refresh_token')?.value
+      const csrfTokenCookies = request.cookies.get('csrf_token')?.value
+      if (!refreshToken || !csrfTokenCookies)
         return NextResponse.redirect(loginUrl)
 
-      const refreshResponse = await refreshAccessToken()
+      const headers = new Headers({
+        'Content-Type': 'application/json',
+        Cookie: `csrf_token=${csrfTokenCookies};refresh_token=${refreshToken}`,
+        'X-CSRF-Token': csrfTokenCookies
+      })
+
+      const refreshResponse = await refreshAccessToken(headers)
       if (refreshResponse.error || !refreshResponse.data) {
         console.error(
           `Failed to refresh token in proxy: ${refreshResponse.error}`

--- a/learn_nextjs/src/proxy.ts
+++ b/learn_nextjs/src/proxy.ts
@@ -1,9 +1,9 @@
 import { jwtVerify } from 'jose'
 import { type NextRequest, NextResponse } from 'next/server'
-import { refreshToken } from './app/api/server-endpoints'
+import { refreshAccessToken } from './app/api/server-endpoints'
 import { SECRET_KEY } from './common/const'
 
-const PROTECTED = ['/items/new']
+const PROTECTED = ['/items/new', '/me']
 const AUTH_ONLY = ['/login', '/signup']
 const JWT_SECRET = new TextEncoder().encode(SECRET_KEY)
 
@@ -12,13 +12,13 @@ export const proxy = async (request: NextRequest) => {
   const redirectTo = (redirectPath: string) =>
     NextResponse.redirect(new URL(`${redirectPath}`, request.url))
 
-  const token = request.cookies.get('access_token')?.value
+  const accessToken = request.cookies.get('access_token')?.value
 
   const isProtected = PROTECTED.some((route) => pathname.startsWith(route))
   const isAuthOnly = AUTH_ONLY.some((route) => pathname.startsWith(route))
 
   if (isProtected) {
-    if (!token) {
+    if (!accessToken) {
       const loginUrl = new URL('/login', request.url)
       loginUrl.searchParams.set(
         'next',
@@ -28,7 +28,7 @@ export const proxy = async (request: NextRequest) => {
       if (!request.cookies.has('refresh_token'))
         return NextResponse.redirect(loginUrl)
 
-      const refreshResponse = await refreshToken()
+      const refreshResponse = await refreshAccessToken()
       if (refreshResponse.error || !refreshResponse.data) {
         console.error(
           `Failed to refresh token in proxy: ${refreshResponse.error}`
@@ -59,7 +59,7 @@ export const proxy = async (request: NextRequest) => {
     }
 
     try {
-      await jwtVerify(token, JWT_SECRET, {
+      await jwtVerify(accessToken, JWT_SECRET, {
         algorithms: ['HS256']
       })
     } catch (error) {
@@ -82,7 +82,7 @@ export const proxy = async (request: NextRequest) => {
     }
   }
 
-  if (isAuthOnly && token) return redirectTo('/')
+  if (isAuthOnly && accessToken) return redirectTo('/')
 
   return NextResponse.next()
 }

--- a/learn_nextjs/src/schemas/items/forms.ts
+++ b/learn_nextjs/src/schemas/items/forms.ts
@@ -7,7 +7,7 @@ import {
 } from '@/app/utils/formInputValidators'
 import type { Item } from '@/common/types/api/resources'
 
-export const itemFormSchema: z.ZodType<Omit<Item, 'id' | 'user_id'>> = z
+export const itemCreateFormSchema: z.ZodType<Omit<Item, 'id' | 'user_id'>> = z
   .object({
     name: stringFromForm('Name is required'),
     description: stringFromForm('Description is required'),
@@ -24,3 +24,17 @@ export const itemFormSchema: z.ZodType<Omit<Item, 'id' | 'user_id'>> = z
       image_url: data.imageUrl ?? undefined
     })
   )
+
+export const itemPatchFormSchema: z.ZodType<
+  Partial<Omit<Item, 'id' | 'user_id'>>
+> = z.object({
+  name: stringFromForm("Name can't be empty").optional(),
+  description: stringFromForm("Description can't be empty").optional(),
+  price: nonNegativeNumberFromForm(
+    'Price must be a non-negative number'
+  ).optional(),
+  tax: nonNegativeNumberFromForm(
+    'Tax must be a non-negative number'
+  ).optional(),
+  imageUrl: nullableImageUrlFromForm.optional()
+})

--- a/learn_nextjs/src/types/api/types.ts
+++ b/learn_nextjs/src/types/api/types.ts
@@ -8,12 +8,24 @@ export type ApiProxyLogoutResponse = { loggedOut: boolean }
 
 export type ApiVersion = (typeof BACKEND_API_VERSIONS)[number]
 
+type AuthContext = {
+  accessToken?: string
+  csrfToken?: string
+}
+
+export interface BuildHeadersOptions {
+  auth?: AuthContext
+  headers?: HeadersInit
+  hasBody?: boolean
+  isSerializedBody?: boolean
+}
+
 export type RequestFactoryOptions = {
   method?: HttpMethod
   pathParam?: string | null
   body?: unknown
-  accessToken?: string | null
   headers?: HeadersInit
+  auth?: AuthContext
   queryParams?: Record<string, string>
   apiVersion?: ApiVersion
   credentials?: RequestCredentials
@@ -31,6 +43,12 @@ export type PromisePathProps = {
 export type APIBaseProps = {
   endpoint: string
   pathParam?: string | null
-  accessToken?: string | null
   apiVersion?: ApiVersion
+}
+
+export type ApiCallInit = {
+  auth?: AuthContext
+  headers?: HeadersInit
+  queryParams?: Record<string, string>
+  credentials?: RequestCredentials
 }

--- a/learn_nextjs/tsconfig.json
+++ b/learn_nextjs/tsconfig.json
@@ -16,10 +16,14 @@
     "plugins": [
       {
         "name": "next"
+      },
+      {
+        "name": "@effect/language-service"
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/api/*": ["./src/app/api/*"]
     },
     "types": ["node", "vitest/globals"]
   },
@@ -32,5 +36,6 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", ".next/dev/types/validator.ts"]
+  "exclude": ["node_modules", ".next/dev/types/validator.ts"],
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json"
 }


### PR DESCRIPTION
- Modified /auth/refresh endpoint to validate refresh tokens directly from cookies
- Removed CurrentUserDep requirement since refresh is used when access_token is expired
- Added new service method refresh_token_from_cookies() to handle cookie-based validation
- Added repository method get_user_from_refresh_token() to retrieve user from refresh token
- Maintains all security measures including CSRF token validation
- Enables proper token refresh flow when access tokens expire
- Fixes the circular dependency where refresh needed valid access_token to work

This change allows the refresh token endpoint to function correctly by validating the refresh token directly from HTTP-only cookies, eliminating the need for a valid access token during the refresh process while maintaining security through CSRF token validation and database-backed refresh token verification.

This commit message follows the conventions:
- Type: feat (feature) since it adds new functionality
- Scope: auth for authentication-related changes
- Subject: Descriptive of what was changed
- Body: Explains the what and why (not how)
- Format: Imperative, present tense, no capital first letter, no trailing dot

The message captures the essence of our discussion about fixing the refresh token endpoint to work properly without requiring a current user, which was the circular dependency problem we identified.