### PR TITLE
feat(services): extract BaseService with shared SSE broadcast helper

### DIFF
--- a/learn_fastapi/src/auth/service.py
+++ b/learn_fastapi/src/auth/service.py
@@ -1,5 +1,6 @@
 import secrets
 from datetime import UTC, datetime
+from uuid import UUID
 
 from fastapi.security import OAuth2PasswordRequestForm
 from starlette.requests import Request
@@ -12,6 +13,7 @@ from learn_fastapi.src.utils.exceptions import (
     email_already_registered_exception,
     user_inactive_exception,
 )
+from learn_fastapi.src.utils.service import BaseService
 
 from .config import auth_config
 from .exceptions import (
@@ -38,7 +40,7 @@ async def _login(
     repository: AuthRepository,
     form_data: OAuth2PasswordRequestForm,
     response: Response,
-) -> tuple[str, str, str]:
+) -> tuple[str, str, str, UUID]:
     """Authenticate a user and mint new access/refresh/csrf tokens.
 
     Args:
@@ -47,10 +49,11 @@ async def _login(
         response: Response object used to set auth cookies.
 
     Returns:
-        (access_token, refresh_token_raw, csrf_token):
+        (access_token, refresh_token_raw, csrf_token, user_id):
             access_token: JWT access token string
             refresh_token_raw: The raw (unhashed) refresh token string
             csrf_token: CSRF token string
+            user_id: UUID of the authenticated user
 
     Raises:
         credentials_exception: If the credentials are invalid.
@@ -85,10 +88,10 @@ async def _login(
 
     set_auth_cookies(response, refresh_token_raw, csrf_token)
 
-    return access_token, refresh_token_raw, csrf_token
+    return access_token, refresh_token_raw, csrf_token, user_id
 
 
-class AuthService:
+class AuthService(BaseService):
     """Service class for auth business logic."""
 
     def __init__(self, session: AsyncSessionDep) -> None:
@@ -112,10 +115,17 @@ class AuthService:
         if existing_user is not None:
             raise email_already_registered_exception()
 
-        return await self.repository.create_user(
+        user = await self.repository.create_user(
             email=str(user_data.email),
             password_hash=hash_password(user_data.password),
         )
+
+        await self._broadcast_sse_event(
+            "auth.registered",
+            {"user_id": str(user.id), "email": user.email},
+        )
+
+        return user
 
     async def login(
         self,
@@ -132,7 +142,15 @@ class AuthService:
             A token response with access and CSRF tokens.
 
         """
-        access_token, _, csrf_token = await _login(self.repository, form_data, response)
+        access_token, _, csrf_token, user_id = await _login(
+            self.repository, form_data, response
+        )
+
+        await self._broadcast_sse_event(
+            "auth.logged_in",
+            {"user_id": str(user_id)},
+            user_id=user_id,
+        )
 
         return Token(
             access_token=access_token,
@@ -202,26 +220,28 @@ class AuthService:
         csrf_token = request.cookies.get("csrf_token")
 
         if (
-            not refresh_token_raw
-            or not csrf_token
-            or not x_csrf_token
-            or csrf_token != x_csrf_token
+            refresh_token_raw
+            and csrf_token
+            and x_csrf_token
+            and csrf_token == x_csrf_token
         ):
-            clear_auth_cookies(response)
-            return
-
-        token_record = await self.repository.get_refresh_token(user.id)
-        if not token_record:
-            clear_auth_cookies(response)
-            return
-        if verify_refresh_token(refresh_token_raw, token_record.token_hash):
-            token_record.revoked_at = datetime.now(tz=UTC)
-            await self.repository.commit()
+            token_record = await self.repository.get_refresh_token(user.id)
+            if token_record and verify_refresh_token(
+                refresh_token_raw, token_record.token_hash
+            ):
+                token_record.revoked_at = datetime.now(tz=UTC)
+                await self.repository.commit()
 
         clear_auth_cookies(response)
 
+        await self._broadcast_sse_event(
+            "auth.logged_out",
+            {"user_id": str(user.id)},
+            user_id=user.id,
+        )
 
-class AuthServiceV2:
+
+class AuthServiceV2(BaseService):
     """Service class for auth business logic for API Version 2."""
 
     def __init__(self, session: AsyncSessionDep) -> None:
@@ -247,8 +267,14 @@ class AuthServiceV2:
                 - CSRF
 
         """
-        access_token, refresh_token_raw, csrf_token = await _login(
+        access_token, refresh_token_raw, csrf_token, user_id = await _login(
             self.repository, form_data, response
+        )
+
+        await self._broadcast_sse_event(
+            "auth.logged_in",
+            {"user_id": str(user_id)},
+            user_id=user_id,
         )
 
         return TokenV2(

--- a/learn_fastapi/src/items/service.py
+++ b/learn_fastapi/src/items/service.py
@@ -3,12 +3,11 @@ from uuid import UUID
 from fastapi import UploadFile
 
 from learn_fastapi.src.database import AsyncSessionDep
-from learn_fastapi.src.sse.manager import sse_manager
 from learn_fastapi.src.users.exceptions import only_user_owner_is_authorized
 from learn_fastapi.src.users.models import User
 from learn_fastapi.src.users.repository import UsersRepository
-from learn_fastapi.src.utils.alembic import app_logger
 from learn_fastapi.src.utils.exceptions import user_doesnt_exist_exception
+from learn_fastapi.src.utils.service import BaseService
 
 from .cache import (
     cache_item,
@@ -30,7 +29,7 @@ from .schema import ItemPatchSchema, ItemSchema, ItemUpdateSchema
 from .utils import save_image_file
 
 
-class ItemService:
+class ItemService(BaseService):
     """Service class for Item business logic."""
 
     def __init__(self, session: AsyncSessionDep) -> None:
@@ -70,33 +69,6 @@ class ItemService:
 
     async def resolve_owner(self, current_user: User, owner_id: UUID | None) -> User:
         return await self._resolve_owner(current_user, owner_id)
-
-    @staticmethod
-    async def _broadcast_sse_event(
-        event: str, payload: dict, user_id: UUID | None = None
-    ) -> None:
-        """Safely broadcast an SSE event, logging failures without raising.
-
-        Wraps SSE broadcast calls to ensure failures don't interrupt business logic.
-        This is a best-effort approach: if SSE is unavailable or fails, the API
-        continues normally.
-
-        Args:
-            event: Event type (e.g., "item.created").
-            payload: Event payload (dict).
-            user_id: Optional user ID for user-scoped events. If None, broadcasts\
-                globally.
-
-        """
-        try:
-            if user_id:
-                await sse_manager.broadcast_user(user_id, event, payload)
-            else:
-                await sse_manager.broadcast_global(event, payload)
-        except Exception:  # noqa: BLE001
-            app_logger.exception(
-                f"Failed to broadcast SSE event '{event}' (user_id={user_id})"
-            )
 
     async def get_all_items(self) -> list[ItemSchema]:
         """Return all items in the database as serialized schemas.

--- a/learn_fastapi/src/users/service.py
+++ b/learn_fastapi/src/users/service.py
@@ -12,6 +12,7 @@ from learn_fastapi.src.utils.exceptions import (
     email_already_registered_exception,
     user_doesnt_exist_exception,
 )
+from learn_fastapi.src.utils.service import BaseService
 
 from .exceptions import incorrect_password_exception, only_user_owner_is_authorized
 from .models import User
@@ -19,7 +20,7 @@ from .repository import UsersRepository
 from .schema import DeleteAccount, UserUpdate
 
 
-class UsersService:
+class UsersService(BaseService):
     """Service class for user account business logic."""
 
     def __init__(self, session: AsyncSessionDep) -> None:
@@ -107,16 +108,29 @@ class UsersService:
         await self.verify_userid_and_auth_user(
             user_id, authorized_user, data.current_password
         )
+
+        changed_fields: list[str] = []
+
         if data.new_email:
             existing = await self.repository.get_user_by_email(data.new_email)
             if existing:
                 raise email_already_registered_exception()
             authorized_user.email = data.new_email
+            changed_fields.append("email")
 
         if data.new_password:
             authorized_user.password_hash = hash_password(data.new_password)
+            changed_fields.append("password")
 
-        return await self.repository.update_user(authorized_user)
+        user = await self.repository.update_user(authorized_user)
+
+        await self._broadcast_sse_event(
+            "user.account_updated",
+            {"user_id": str(user.id), "changed_fields": changed_fields},
+            user_id=user.id,
+        )
+
+        return user
 
     async def delete_account(
         self,
@@ -136,4 +150,11 @@ class UsersService:
         """
         await self.verify_userid_and_auth_user(user_id, authorized_user, data.password)
         await self.repository.delete_user(authorized_user)
+
+        await self._broadcast_sse_event(
+            "user.account_deleted",
+            {"user_id": str(authorized_user.id)},
+            user_id=authorized_user.id,
+        )
+
         clear_auth_cookies(response)

--- a/learn_fastapi/src/utils/service.py
+++ b/learn_fastapi/src/utils/service.py
@@ -1,0 +1,41 @@
+"""Base service class with shared SSE broadcasting utilities."""
+
+from uuid import UUID
+
+from learn_fastapi.src.sse.manager import sse_manager
+from learn_fastapi.src.utils.alembic import app_logger
+
+
+class BaseService:
+    """Base class for all service layers.
+
+    Provides a shared ``_broadcast_sse_event`` helper so every subclass can
+    emit SSE events without duplicating the try/except guard and logging.
+    """
+
+    @staticmethod
+    async def _broadcast_sse_event(
+        event: str, payload: dict, user_id: UUID | None = None
+    ) -> None:
+        """Safely broadcast an SSE event, logging failures without raising.
+
+        Wraps SSE broadcast calls to ensure failures don't interrupt business
+        logic. This is a best-effort approach: if SSE is unavailable or fails,
+        the API continues normally.
+
+        Args:
+            event: Event type (e.g., ``"item.created"``).
+            payload: Event payload dict.
+            user_id: Optional user ID for user-scoped events. When ``None``
+                the event is broadcast globally to all connected clients.
+
+        """
+        try:
+            if user_id:
+                await sse_manager.broadcast_user(user_id, event, payload)
+            else:
+                await sse_manager.broadcast_global(event, payload)
+        except Exception:  # noqa: BLE001
+            app_logger.exception(
+                f"Failed to broadcast SSE event '{event}' (user_id={user_id})"
+            )


### PR DESCRIPTION
- Add BaseService in utils/service.py with _broadcast_sse_event static method
- ItemService, AuthService, AuthServiceV2, and UsersService all inherit BaseService
- Remove duplicate _broadcast_sse_event from ItemService
- Auth: broadcast auth.registered (global), auth.logged_in / auth.logged_out (user-scoped)
- Users: broadcast user.account_updated with changed_fields, user.account_deleted (user-scoped)
- Extend _login helper return type to include user_id (UUID) for SSE in login flows

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>