### PR TITLE
[learn_fastapi] Store Cloudinary image public IDs

### DIFF
--- a/learn_fastapi/README.md
+++ b/learn_fastapi/README.md
@@ -109,7 +109,8 @@ learn_fastapi/
 |   |   |   └── test_router.py  # User account endpoints tests
 |   |   ├── items/
 |   |   |   ├── conftest.py     # Item fixtures (test_user, sample_item, seeded_item)
-|   |   |   └── test_router.py  # Item CRUD endpoints tests
+|   |   |   ├── test_router.py  # Item CRUD endpoints tests
+|   |   |   └── test_utils.py   # Cloudinary image helper tests
 |   |   ├── conftest.py # V1 global fixtures (if needed)
 |   |   └── test_items_authorization.py # Authorization tests for item ownership
 |   ├── v2/
@@ -166,8 +167,9 @@ Base prefix: `/items`
 #### `items` media uploads with Cloudinary
 
 The items module now uploads item images to Cloudinary instead of persisting new uploads in the local
-`src/media/images` folder. This keeps the API stateless for media files and lets frontend clients render the
-Cloudinary-hosted `secure_url` stored on each item as `image_url`.
+`src/media/images` folder. This keeps the API stateless for media files, lets frontend clients render the
+Cloudinary-hosted `secure_url` stored on each item as `image_url`, and stores Cloudinary's `public_id` internally as
+`image_public_id` so replacements can delete the previous asset without parsing URLs.
 
 **Configuration:**
 
@@ -190,9 +192,10 @@ FastAPI-Ecosystem-Lab/media
 1. `POST /items/image/{id_param}` receives `multipart/form-data` with `image_file` and optional `caption`.
 2. The route requires `CurrentUserDep`; regular users can only update images for their own items, while superusers can
    update any item.
-3. `src/items/utils.py` signs the Cloudinary upload parameters and sends the file with `httpx.AsyncClient`.
-4. Cloudinary returns a `secure_url`, which is saved on the item as `image_url`.
-5. Item cache entries are invalidated and an `item.image_updated` SSE event is broadcast to the owner.
+3. If the item already has an `image_public_id`, the service deletes that Cloudinary asset first.
+4. `src/items/utils.py` configures the Cloudinary Python SDK and uploads the file with `cloudinary.uploader.upload`.
+5. Cloudinary returns a `secure_url` and `public_id`, which are saved on the item as `image_url` and `image_public_id`.
+6. Item cache entries are invalidated and an `item.image_updated` SSE event is broadcast to the owner.
 
 `POST /items/with-image/` uses the same Cloudinary helper when an image is included during item creation.
 
@@ -201,6 +204,8 @@ FastAPI-Ecosystem-Lab/media
 - Missing Cloudinary variables raise a runtime error only when an image upload is attempted.
 - `PUT /items/{id_param}` and `PATCH /items/{id_param}` accept `image_url` for API compatibility, but normal user-facing
   image changes should go through the upload endpoint so the backend controls media storage.
+- Direct `image_url` edits clear `image_public_id` because those URLs did not come from the backend Cloudinary upload
+  flow.
 
 #### `items` cacheing with Redis
 

--- a/learn_fastapi/alembic/versions/9f3b7c2a1d4e_add_item_image_public_id.py
+++ b/learn_fastapi/alembic/versions/9f3b7c2a1d4e_add_item_image_public_id.py
@@ -1,0 +1,31 @@
+"""add_item_image_public_id
+
+Revision ID: 9f3b7c2a1d4e
+Revises: d8c2bf03d3ff
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9f3b7c2a1d4e"
+down_revision: Union[str, Sequence[str], None] = "d8c2bf03d3ff"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("items", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("image_public_id", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("items", schema=None) as batch_op:
+        batch_op.drop_column("image_public_id")

--- a/learn_fastapi/src/items/annotations.py
+++ b/learn_fastapi/src/items/annotations.py
@@ -18,6 +18,7 @@ float_default = Annotated[
     float, mapped_column(CheckConstraint("price >= 0"), default=0.00)
 ]
 str_url = Annotated[str, mapped_column(default="")]
+str_nullable = Annotated[str | None, mapped_column(default=None, nullable=True)]
 
 # ---------------------------------------------------------------------------
 # Item Form field annotations

--- a/learn_fastapi/src/items/models.py
+++ b/learn_fastapi/src/items/models.py
@@ -17,6 +17,7 @@ from .annotations import (
     float_default,
     str_default,
     str_indexed,
+    str_nullable,
     str_url,
 )
 
@@ -33,6 +34,7 @@ class Item(Base):
     price: Mapped[float_default]
     tax: Mapped[float_default]
     image_url: Mapped[str_url]
+    image_public_id: Mapped[str_nullable]
     created_at: Mapped[timestamp_created]
     updated_at: Mapped[timestamp_updated]
     user_id: Mapped[user_id_fk]

--- a/learn_fastapi/src/items/repository.py
+++ b/learn_fastapi/src/items/repository.py
@@ -154,6 +154,9 @@ class ItemRepository(BaseRepository):
             return None
 
         values = item_data.model_dump(exclude=exclude_args, exclude_none=True)
+        if "image_url" in values:
+            values["image_public_id"] = None
+
         await self.session.execute(update(Item).where(condition).values(**values))
         await self.session.commit()
         await self.session.refresh(item)
@@ -189,17 +192,23 @@ class ItemRepository(BaseRepository):
         values = item_data.model_dump(
             exclude=exclude_args, exclude_none=True, exclude_unset=True
         )
+        if "image_url" in values:
+            values["image_public_id"] = None
+
         await self.session.execute(update(Item).where(condition).values(**values))
         await self.commit()
         await self.session.refresh(item)
         return item
 
-    async def update_item_image(self, item_id: UUID, image_url: str) -> Item | None:
-        """Update the image_url of an item.
+    async def update_item_image(
+        self, item_id: UUID, image_url: str, image_public_id: str
+    ) -> Item | None:
+        """Update the Cloudinary image metadata of an item.
 
         Args:
             item_id: The UUID of the item to update.
             image_url: The new image URL to store on the item.
+            image_public_id: The Cloudinary public ID for deletion/replacement.
 
         Returns:
             The updated Item.
@@ -213,7 +222,9 @@ class ItemRepository(BaseRepository):
             return None
 
         await self.session.execute(
-            update(Item).where(id_bool_column).values(image_url=image_url)
+            update(Item)
+            .where(id_bool_column)
+            .values(image_url=image_url, image_public_id=image_public_id)
         )
         await self.commit()
         await self.session.refresh(item)

--- a/learn_fastapi/src/items/schema.py
+++ b/learn_fastapi/src/items/schema.py
@@ -12,6 +12,7 @@ class ImageSchema(BaseModel):
         description="The MIME type of the image", default=None
     )
     url: str = Field(description="The url of the image", default="")
+    public_id: str = Field(description="The Cloudinary public ID", default="")
 
 
 class ItemSchema(BaseModel):

--- a/learn_fastapi/src/items/service.py
+++ b/learn_fastapi/src/items/service.py
@@ -26,7 +26,7 @@ from .exceptions import (
 )
 from .repository import ItemRepository
 from .schema import ItemPatchSchema, ItemSchema, ItemUpdateSchema
-from .utils import delete_image_file, extract_cloudinary_public_id, save_image_file
+from .utils import delete_image_file, save_image_file
 
 
 class ItemService(BaseService):
@@ -247,7 +247,7 @@ class ItemService(BaseService):
 
         if image_file:
             image = await save_image_file(image_file, caption)
-            await self.repository.update_item_image(item.id, image.url)
+            await self.repository.update_item_image(item.id, image.url, image.public_id)
 
         schema = ItemSchema.model_validate(item, from_attributes=True)
 
@@ -396,15 +396,15 @@ class ItemService(BaseService):
         if item is None:
             raise item_not_found_or_not_belong_to_user_exception()
 
-        if item.image_url:
-            image_id = extract_cloudinary_public_id(item.image_url)
-            await delete_image_file(image_id)
-            await self.repository.patch_item(
-                item_id, ItemPatchSchema(image_url=None), owner
-            )
+        if item.image_public_id:
+            await delete_image_file(item.image_public_id)
 
         image = await save_image_file(image_file, caption)
-        item = await self.repository.update_item_image(item.id, image.url)
+        item = await self.repository.update_item_image(
+            item.id,
+            image.url,
+            image.public_id,
+        )
 
         if item is None:
             raise item_not_found_or_not_belong_to_user_exception()

--- a/learn_fastapi/src/items/utils.py
+++ b/learn_fastapi/src/items/utils.py
@@ -1,9 +1,13 @@
-from hashlib import sha1
+from asyncio import to_thread
+from pathlib import PurePosixPath
+from re import fullmatch
 from time import time
+from typing import Any
 from urllib.parse import urlparse
 from uuid import uuid4
 
-import httpx
+import cloudinary
+import cloudinary.uploader
 from fastapi import UploadFile
 
 from learn_fastapi.src.config import settings
@@ -41,22 +45,15 @@ def _get_cloudinary_config() -> tuple[str, str, str]:
     )
 
 
-def _sign_cloudinary_params(params: dict[str, str], api_secret: str) -> str:
-    """Create a Cloudinary upload signature from signed request parameters.
-
-    Args:
-        params: The parameters to include in the signature, such as
-            timestamp and public_id.
-        api_secret: The Cloudinary API secret key.
-
-    Returns:
-        The SHA-1 hash signature string for the given parameters and API secret.
-
-    """
-    signature_payload = "&".join(
-        f"{key}={value}" for key, value in sorted(params.items())
+def _configure_cloudinary() -> None:
+    """Configure Cloudinary's SDK from application settings."""
+    cloud_name, api_key, api_secret = _get_cloudinary_config()
+    cloudinary.config(
+        cloud_name=cloud_name,
+        api_key=api_key,
+        api_secret=api_secret,
+        secure=True,
     )
-    return sha1(f"{signature_payload}{api_secret}".encode()).hexdigest()  # noqa: S324
 
 
 async def save_image_file(
@@ -73,48 +70,45 @@ async def save_image_file(
 
     Raises:
         image_filename_required_exception: If the image file does not have a filename.
+        TypeError:
+            If the Cloudinary upload response does not include a valid secure_url
+            or public_id.
 
     """
     if not image_file.filename:
         raise image_filename_required_exception()
 
-    cloud_name, api_key, api_secret = _get_cloudinary_config()
+    _configure_cloudinary()
     timestamp = int(time())
     public_id = f"{uuid4()}-{timestamp}"
-    upload_params = {
-        "asset_folder": CLOUDINARY_ASSET_FOLDER,
-        "public_id": public_id,
-        "timestamp": str(timestamp),
-    }
-    upload_url = f"https://api.cloudinary.com/v1_1/{cloud_name}/image/upload"
-    image_bytes = await image_file.read()
 
-    async with httpx.AsyncClient(timeout=CLOUDINARY_UPLOAD_TIMEOUT) as client:
-        response = await client.post(
-            upload_url,
-            data={
-                "api_key": api_key,
-                "asset_folder": upload_params["asset_folder"],
-                "public_id": upload_params["public_id"],
-                "timestamp": upload_params["timestamp"],
-                "signature": _sign_cloudinary_params(upload_params, api_secret),
-            },
-            files={
-                "file": (
-                    image_file.filename,
-                    image_bytes,
-                    image_file.content_type or "application/octet-stream",
-                )
-            },
-        )
-        response.raise_for_status()
+    await image_file.seek(0)
+    # The Cloudinary SDK signs and sends the request for us; running it in a
+    #   thread keeps the async endpoint from blocking on network I/O.
+    upload_result: dict[str, Any] = await to_thread(
+        cloudinary.uploader.upload,
+        image_file.file,
+        asset_folder=CLOUDINARY_ASSET_FOLDER,
+        public_id=public_id,
+        resource_type="image",
+        timeout=CLOUDINARY_UPLOAD_TIMEOUT,
+    )
+    image_url = upload_result.get("secure_url")
+    if not isinstance(image_url, str):
+        msg = "Cloudinary upload response did not include secure_url."
+        raise TypeError(msg)
 
-    upload_result = response.json()
+    image_public_id = upload_result.get("public_id")
+    if not isinstance(image_public_id, str):
+        msg = "Cloudinary upload response did not include public_id."
+        raise TypeError(msg)
+
     return ImageSchema(
         name=image_file.filename,
         description=caption,
         content_type=image_file.content_type,
         url=upload_result["secure_url"],
+        public_id=image_public_id,
     )
 
 
@@ -131,11 +125,24 @@ def extract_cloudinary_public_id(image_url: str) -> str:
     # Cloudinary URLs are typically in the format:
     # https://res.cloudinary.com/{cloud_name}/image/upload/v{version}/{public_id}.{format}
     # We can use urlparse to extract the path and then split it to get the public_id
-
     parsed_url = urlparse(image_url)
-    path_parts = parsed_url.path.split("/")
+    path_parts = [part for part in parsed_url.path.split("/") if part]
+    if not path_parts:
+        return ""
 
-    return path_parts[-1].split(".")[0]
+    if "upload" not in path_parts:
+        return PurePosixPath(path_parts[-1]).with_suffix("").as_posix()
+
+    public_id_parts = path_parts[path_parts.index("upload") + 1 :]
+    for index, part in enumerate(public_id_parts):
+        if fullmatch(r"v\d+", part):
+            public_id_parts = public_id_parts[index + 1 :]
+            break
+
+    if not public_id_parts:
+        return ""
+
+    return PurePosixPath("/".join(public_id_parts)).with_suffix("").as_posix()
 
 
 async def delete_image_file(image_public_id: str) -> bool:
@@ -148,25 +155,16 @@ async def delete_image_file(image_public_id: str) -> bool:
         Success: True | False
 
     """
-    cloud_name, api_key, api_secret = _get_cloudinary_config()
-    timestamp = int(time())
-    delete_url = f"https://api.cloudinary.com/v1_1/{cloud_name}/image/destroy"
-    upload_params = {
-        "public_id": image_public_id,
-        "timestamp": str(timestamp),
-    }
+    if not image_public_id:
+        return False
 
-    async with httpx.AsyncClient(timeout=CLOUDINARY_UPLOAD_TIMEOUT) as client:
-        response = await client.post(
-            delete_url,
-            data={
-                "public_id": image_public_id,
-                "api_key": api_key,
-                "timestamp": upload_params["timestamp"],
-                "signature": _sign_cloudinary_params(upload_params, api_secret),
-            },
-        )
-        response.raise_for_status()
+    _configure_cloudinary()
+    delete_result: dict[str, Any] = await to_thread(
+        cloudinary.uploader.destroy,
+        image_public_id,
+        resource_type="image",
+        invalidate=True,
+    )
 
     # result = "ok" | "not found"
-    return response.json()["result"] == "ok"
+    return delete_result.get("result") == "ok"

--- a/learn_fastapi/tests/v1/items/test_router.py
+++ b/learn_fastapi/tests/v1/items/test_router.py
@@ -15,12 +15,12 @@ from starlette.status import (
     HTTP_422_UNPROCESSABLE_CONTENT,
 )
 
+from learn_fastapi.src.items.models import Item as ItemModel
 from learn_fastapi.src.items.schema import ImageSchema
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
-
-    from learn_fastapi.src.items.models import Item as ItemModel
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.fixture
@@ -39,12 +39,30 @@ def fake_cloudinary_upload(monkeypatch: pytest.MonkeyPatch) -> None:
                 "https://res.cloudinary.com/test/image/upload/"
                 f"FastAPI-Ecosystem-Lab/media/{image_file.filename}"
             ),
+            public_id=f"FastAPI-Ecosystem-Lab/media/{image_file.filename}",
         )
 
     monkeypatch.setattr(
         "learn_fastapi.src.items.service.save_image_file",
         fake_save_image_file,
     )
+
+
+@pytest.fixture
+def fake_cloudinary_delete(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    deleted_public_ids: list[str] = []
+
+    async def fake_delete_image_file(image_public_id: str) -> bool:
+        # Preserve the awaited production contract while avoiding Cloudinary I/O.
+        await sleep(0)
+        deleted_public_ids.append(image_public_id)
+        return True
+
+    monkeypatch.setattr(
+        "learn_fastapi.src.items.service.delete_image_file",
+        fake_delete_image_file,
+    )
+    return deleted_public_ids
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +335,25 @@ class TestUpdateItem:
         assert response.status_code == HTTP_200_OK
         assert response.json()["image_url"] == image_url
 
+    async def test_update_clears_stale_image_public_id(
+        self,
+        client: AsyncClient,
+        sample_item: dict,
+        seeded_item: ItemModel,
+        test_session: AsyncSession,
+    ) -> None:
+        seeded_item.image_public_id = "FastAPI-Ecosystem-Lab/media/old"
+        await test_session.commit()
+
+        response = await client.put(
+            f"/items/{seeded_item.id}",
+            json={**sample_item, "image_url": "https://example.com/images/item.png"},
+        )
+
+        assert response.status_code == HTTP_200_OK
+        await test_session.refresh(seeded_item)
+        assert seeded_item.image_public_id is None
+
     async def test_invalid_payload_returns_422(
         self, client: AsyncClient, seeded_item: ItemModel
     ) -> None:
@@ -345,6 +382,24 @@ class TestPatchItem:
         )
         assert response.status_code == HTTP_200_OK
         assert response.json()["image_url"] == image_url
+
+    async def test_patch_clears_stale_image_public_id(
+        self,
+        client: AsyncClient,
+        seeded_item: ItemModel,
+        test_session: AsyncSession,
+    ) -> None:
+        seeded_item.image_public_id = "FastAPI-Ecosystem-Lab/media/old"
+        await test_session.commit()
+
+        response = await client.patch(
+            f"/items/{seeded_item.id}",
+            json={"image_url": "https://example.com/images/patched-item.png"},
+        )
+
+        assert response.status_code == HTTP_200_OK
+        await test_session.refresh(seeded_item)
+        assert seeded_item.image_public_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +473,21 @@ class TestSubmitItemImage:
             "FastAPI-Ecosystem-Lab/media/test.png"
         )
 
+    async def test_image_public_id_saved(
+        self,
+        client: AsyncClient,
+        seeded_item: ItemModel,
+        test_session: AsyncSession,
+    ) -> None:
+        response = await client.post(
+            f"/items/image/{seeded_item.id}",
+            files={"image_file": ("test.png", self.FAKE_PNG, "image/png")},
+        )
+
+        assert response.status_code == HTTP_200_OK
+        await test_session.refresh(seeded_item)
+        assert seeded_item.image_public_id == "FastAPI-Ecosystem-Lab/media/test.png"
+
     async def test_item_name_unchanged(
         self, client: AsyncClient, seeded_item: ItemModel
     ) -> None:
@@ -426,6 +496,29 @@ class TestSubmitItemImage:
             files={"image_file": ("test.png", self.FAKE_PNG, "image/png")},
         )
         assert response.json()["name"] == "Foo"
+
+    async def test_existing_cloudinary_image_is_deleted_before_replacement(
+        self,
+        client: AsyncClient,
+        seeded_item: ItemModel,
+        fake_cloudinary_delete: list[str],
+        test_session: AsyncSession,
+    ) -> None:
+        old_image_url = (
+            "https://res.cloudinary.com/test/image/upload/v123/"
+            "FastAPI-Ecosystem-Lab/media/old.png"
+        )
+        seeded_item.image_url = old_image_url
+        seeded_item.image_public_id = "FastAPI-Ecosystem-Lab/media/old"
+        await test_session.commit()
+
+        response = await client.post(
+            f"/items/image/{seeded_item.id}",
+            files={"image_file": ("test.png", self.FAKE_PNG, "image/png")},
+        )
+
+        assert response.status_code == HTTP_200_OK
+        assert fake_cloudinary_delete == ["FastAPI-Ecosystem-Lab/media/old"]
 
     async def test_non_existing_id_returns_404(self, client: AsyncClient) -> None:
         random_id = uuid.uuid4()
@@ -509,6 +602,27 @@ class TestCreateItemWithImage:
             == "https://res.cloudinary.com/test/image/upload/"
             "FastAPI-Ecosystem-Lab/media/product.png"
         )
+
+    async def test_image_public_id_saved_when_file_provided(
+        self,
+        client: AsyncClient,
+        test_session: AsyncSession,
+    ) -> None:
+        response = await client.post(
+            "/items/with-image/",
+            data={
+                "name": "Image Item",
+                "description": "A long enough description",
+                "price": "5.00",
+            },
+            files={"image_file": ("product.png", self.FAKE_PNG, "image/png")},
+        )
+
+        assert response.status_code in {HTTP_200_OK, HTTP_201_CREATED}
+
+        item = await test_session.get(ItemModel, UUID(response.json()["id"]))
+        assert item is not None
+        assert item.image_public_id == "FastAPI-Ecosystem-Lab/media/product.png"
 
     async def test_default_values_used(self, client: AsyncClient) -> None:
         item_name = "Default Item"

--- a/learn_fastapi/tests/v1/items/test_utils.py
+++ b/learn_fastapi/tests/v1/items/test_utils.py
@@ -1,0 +1,84 @@
+from io import BytesIO
+from typing import Any
+
+import pytest
+from fastapi import UploadFile
+from pydantic import SecretStr
+from starlette.datastructures import Headers
+
+from learn_fastapi.src.constants import CLOUDINARY_ASSET_FOLDER
+from learn_fastapi.src.items import utils
+
+
+@pytest.fixture(autouse=True)
+def cloudinary_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(utils.settings, "cloudinary_cloud_name", "test-cloud")
+    monkeypatch.setattr(utils.settings, "cloudinary_api_key", SecretStr("test-key"))
+    monkeypatch.setattr(
+        utils.settings, "cloudinary_api_secret", SecretStr("test-secret")
+    )
+
+
+async def test_save_image_file_uses_cloudinary_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_config(**kwargs: Any) -> None:
+        captured["config"] = kwargs
+
+    def fake_upload(file: BytesIO, **kwargs: Any) -> dict[str, str]:
+        captured["file"] = file
+        captured["upload"] = kwargs
+        return {
+            "public_id": "FastAPI-Ecosystem-Lab/media/new",
+            "secure_url": "https://res.cloudinary.com/test/image/upload/new.png",
+        }
+
+    monkeypatch.setattr(utils.cloudinary, "config", fake_config)
+    monkeypatch.setattr(utils.cloudinary.uploader, "upload", fake_upload)
+
+    image_file = UploadFile(
+        file=BytesIO(b"png"),
+        filename="product.png",
+        headers=Headers({"content-type": "image/png"}),
+    )
+
+    image = await utils.save_image_file(image_file, "Product image")
+
+    assert image.url == "https://res.cloudinary.com/test/image/upload/new.png"
+    assert image.public_id == "FastAPI-Ecosystem-Lab/media/new"
+    assert image.content_type == "image/png"
+    assert captured["config"] == {
+        "cloud_name": "test-cloud",
+        "api_key": "test-key",
+        "api_secret": "test-secret",
+        "secure": True,
+    }
+    assert captured["file"] is image_file.file
+    assert captured["upload"]["asset_folder"] == CLOUDINARY_ASSET_FOLDER
+    assert captured["upload"]["resource_type"] == "image"
+    assert captured["upload"]["timeout"] == utils.CLOUDINARY_UPLOAD_TIMEOUT
+    assert captured["upload"]["public_id"]
+
+
+async def test_delete_image_file_uses_cloudinary_sdk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_config(**kwargs: Any) -> None:
+        captured["config"] = kwargs
+
+    def fake_destroy(public_id: str, **kwargs: Any) -> dict[str, str]:
+        captured["public_id"] = public_id
+        captured["destroy"] = kwargs
+        return {"result": "ok"}
+
+    monkeypatch.setattr(utils.cloudinary, "config", fake_config)
+    monkeypatch.setattr(utils.cloudinary.uploader, "destroy", fake_destroy)
+
+    assert await utils.delete_image_file("FastAPI-Ecosystem-Lab/media/old") is True
+    assert captured["public_id"] == "FastAPI-Ecosystem-Lab/media/old"
+    assert captured["destroy"] == {"resource_type": "image", "invalidate": True}
+    assert captured["config"]["cloud_name"] == "test-cloud"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ dependencies = [
   "alembic>=1.18.4",
   "argon2-cffi>=25.1.0",
   "asyncpg>=0.31.0",
+  "cloudinary>=1.44.2",
   "email-validator>=2.3.0",
   "fakeredis>=2.35.1",
   "fastapi-versionizer>=4.0.2",
   "fastapi[standard-no-fastapi-cloud-cli]>=0.135.1",
-  "httpx>=0.28.1",
   "pre-commit>=4.5.1",
   "psycopg[binary]>=3.3.3",
   "pydantic-settings>=2.13.1",
@@ -34,6 +34,7 @@ dev = [
   "ty>=0.0.17",
 ]
 streamlit-deps = [
+  "httpx>=0.28.1",
   "streamlit>=1.55.0",
 ]
 types-stubs = []

--- a/uv.lock
+++ b/uv.lock
@@ -284,6 +284,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudinary"
+version = "1.44.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "six" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/1b/ae48dbbe3c2ff81b94816dd6645af2d609e135cea4fcd65b1a8a61672cea/cloudinary-1.44.2.tar.gz", hash = "sha256:bc9139c68f2ef6996ba62a5d0300e63c711d4f6564644c0c82aa31bf641ef3c7", size = 188389, upload-time = "2026-04-16T08:18:19.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/8b/0da00a22362c89ef53f9d64af29546d24aba8533ffdb7bbcb19631c7f636/cloudinary-1.44.2-py3-none-any.whl", hash = "sha256:6624d06014c33f50c0c9e740fde1dfe4579d03311025d8bb7183824b7443aa09", size = 147805, upload-time = "2026-04-16T08:18:18.84Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -454,11 +468,11 @@ dependencies = [
     { name = "alembic" },
     { name = "argon2-cffi" },
     { name = "asyncpg" },
+    { name = "cloudinary" },
     { name = "email-validator" },
     { name = "fakeredis" },
     { name = "fastapi", extra = ["standard-no-fastapi-cloud-cli"] },
     { name = "fastapi-versionizer" },
-    { name = "httpx" },
     { name = "pre-commit" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
@@ -479,6 +493,7 @@ dev = [
     { name = "ty" },
 ]
 streamlit-deps = [
+    { name = "httpx" },
     { name = "streamlit" },
 ]
 
@@ -488,11 +503,11 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "argon2-cffi", specifier = ">=25.1.0" },
     { name = "asyncpg", specifier = ">=0.31.0" },
+    { name = "cloudinary", specifier = ">=1.44.2" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fakeredis", specifier = ">=2.35.1" },
     { name = "fastapi", extras = ["standard-no-fastapi-cloud-cli"], specifier = ">=0.135.1" },
     { name = "fastapi-versionizer", specifier = ">=4.0.2" },
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
@@ -512,7 +527,10 @@ dev = [
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "ty", specifier = ">=0.0.17" },
 ]
-streamlit-deps = [{ name = "streamlit", specifier = ">=1.55.0" }]
+streamlit-deps = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "streamlit", specifier = ">=1.55.0" },
+]
 types-stubs = []
 
 [[package]]


### PR DESCRIPTION
# PR Title

[learn_fastapi] Store Cloudinary image public IDs

## Summary

- Store Cloudinary `public_id` values for item images so replacements can delete the previous asset without parsing `image_url`.
- Migrate the item image flow from manual Cloudinary HTTP requests to the Cloudinary Python SDK.
- Add an Alembic migration, focused tests, and README updates for the Cloudinary-backed item image lifecycle.

## Scope

- [x] `learn_fastapi` - FastAPI backend/API
- [ ] `learn_nextjs` - Next.js frontend
- [ ] `learn_streamlit` - Streamlit dashboard/prototype
- [x] Root/tooling/docs - CI, Docker, dependency management, README, shared config

## Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [x] Documentation
- [ ] CI/build/tooling
- [x] Dependency update

## Changes

- Added nullable `items.image_public_id` via Alembic revision `9f3b7c2a1d4e`.
- Persist `image_url` and `image_public_id` together after Cloudinary uploads.
- Delete an existing Cloudinary image by stored `image_public_id` before replacing it.
- Removed URL parsing helper for deriving Cloudinary public IDs from image URLs.
- Clear stale `image_public_id` when `image_url` is edited directly through PUT/PATCH compatibility paths.
- Added `cloudinary>=1.44.2` and updated `uv.lock`.
- Added tests for SDK upload/delete wrappers, public ID persistence, image replacement deletion, and stale public ID cleanup.
- Updated `learn_fastapi/README.md` to document the new Cloudinary image metadata behavior.

## Behavior and Risk Notes

- [ ] API contract changed
- [x] Database schema or Alembic migration changed
- [ ] Authentication, authorization, cookies, or security behavior changed
- [ ] Environment variables or secrets configuration changed
- [x] External service integration changed
- [x] Media/file upload behavior changed
- [ ] Frontend routing, caching, forms, or protected pages changed
- [ ] No high-risk behavior changed

Notes:

- Existing rows are not backfilled because deriving public IDs from historical URLs is the behavior this change removes. New uploads store Cloudinary's returned `public_id` directly.
- `image_public_id` is internal backend metadata and is not exposed in `ItemSchema` responses.
- Existing Cloudinary environment variable names remain unchanged.

## Validation

Mark only the checks that apply.

### FastAPI

- [x] `uv run pytest --config-file=pyproject.toml`
- [x] `uv run ruff check learn_fastapi`
- [x] `uv run ruff format --check learn_fastapi`
- [x] `uv run ty check learn_fastapi`
- [x] Alembic migration reviewed, if applicable
- [x] External services are mocked or safely isolated in tests, if applicable

### Next.js

- [ ] `bun run test`
- [ ] `bun run check`
- [ ] `bun run tsc`
- [ ] `bun run build`
- [ ] Relevant UI flow checked manually, if applicable

### Streamlit

- [ ] App starts locally with `uv run streamlit run learn_streamlit/src/app.py`
- [ ] Relevant dashboard/data flow checked manually, if applicable

### Repository

- [ ] `.env.example` or related docs updated for any configuration changes
- [x] No real secrets, credentials, tokens, or private keys were committed
- [x] Large files and generated artifacts were not committed unintentionally
- [x] Documentation updated where behavior changed

## Screenshots or Evidence

- `uv run ruff check learn_fastapi` passed.
- `uv run ruff format --check learn_fastapi` passed.
- `uv run ty check learn_fastapi` passed.
- `$env:DEBUG='True'; uv run pytest` passed: `94 passed`.
- `cd learn_fastapi; $env:DEBUG='True'; uv run alembic heads` returned `9f3b7c2a1d4e (head)`.
- `git diff --cached --check` passed before commit.

## Reviewer Notes

- The PR intentionally keeps historical rows nullable for `image_public_id` instead of attempting to infer values from existing URLs.
- The branch is based on `main` and contains commit `225107d feat(items): store Cloudinary image public IDs`.
