### PR TITLE
[learn_fastapi] Harden item domain entities

### DIFF
--- a/learn_fastapi/src/items/domain/entities.py
+++ b/learn_fastapi/src/items/domain/entities.py
@@ -8,7 +8,7 @@ from learn_fastapi.src.items.domain.value_objects import (
 from learn_fastapi.src.shared.domain.value_object import ItemId, UserId
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class Item:
     """Domain entity representing an item."""
 
@@ -33,6 +33,17 @@ class Item:
     @property
     def has_image(self) -> bool:
         return self.image_url is not None and self.image_public_id is not None
+
+
+class PersistedItem:
+    """Domain entity representing a persistent item."""
+
+    id: ItemId
+    owner_id: UserId
+    name: str
+    description: str
+    price: float
+    tax: float
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary

- Makes the Item domain entity immutable.
- Adds a PersistedItem domain shape for item records with guaranteed identity and owner data.

## Scope

- [x] learn_fastapi - FastAPI backend/API
- [ ] learn_nextjs - Next.js frontend
- [ ] learn_streamlit - Streamlit dashboard/prototype
- [ ] Root/tooling/docs - CI, Docker, dependency management, README, shared config

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/build/tooling
- [ ] Dependency update

## Changes

- Marks Item as a frozen dataclass to keep domain state immutable after construction.
- Introduces PersistedItem for future clean architecture boundaries where an item must already have an id.

## Behavior and Risk Notes

- [ ] API contract changed
- [ ] Database schema or Alembic migration changed
- [ ] Authentication, authorization, cookies, or security behavior changed
- [ ] Environment variables or secrets configuration changed
- [ ] External service integration changed
- [ ] Media/file upload behavior changed
- [ ] Frontend routing, caching, forms, or protected pages changed
- [x] No high-risk behavior changed

Notes:

- This is a domain-only refactor; no route or persistence behavior changes are intended.

## Validation

### FastAPI

- [ ] uv run pytest --config-file=pyproject.toml
- [x] uv run ruff check learn_fastapi/src/items/domain/entities.py
- [x] uv run ruff format --check learn_fastapi/src/items/domain/entities.py
- [x] uv run ty check learn_fastapi/src/items/domain/entities.py
- [x] DEBUG=True uv run pytest --config-file=pyproject.toml learn_fastapi/tests/v1/items
- [x] Alembic migration reviewed, if applicable
- [x] External services are mocked or safely isolated in tests, if applicable

### Repository

- [x] No real secrets, credentials, tokens, or private keys were committed
- [x] Large files and generated artifacts were not committed unintentionally

## Screenshots or Evidence

- Items scoped tests: 59 passed.

## Reviewer Notes

- This PR is intentionally split from the auth clean architecture branch because the item entity change is independent.