### PR TITLE
[learn_fastapi] Clarify item clean repository contracts

### DIFF
--- a/learn_fastapi/src/items/application/use_cases.py
+++ b/learn_fastapi/src/items/application/use_cases.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from learn_fastapi.src.items.application.queries import (
     GetItemQuery,
     GetOwnerItemQuery,
@@ -9,18 +11,17 @@ from learn_fastapi.src.items.domain.errors import (
     ItemNotFoundForUserError,
     ItemsNotFoundForUserError,
 )
-from learn_fastapi.src.items.domain.ports import ItemRepository
+from learn_fastapi.src.items.domain.ports import ItemsRepository
 
 
-class BaseUseCase:
-    """Base class for all use cases."""
+@dataclass(slots=True)
+class BaseItemsUseCase:
+    """Base class for all `items` app use cases."""
 
-    def __init__(self, item_repository: ItemRepository) -> None:
-        """Initialize the use case with the item repository."""
-        self.item_repository = item_repository
+    items_repository: ItemsRepository
 
 
-class ListItemsUseCase(BaseUseCase):
+class ListItemsUseCase(BaseItemsUseCase):
     """Use case for retrieving all items."""
 
     async def execute(self) -> list[Item]:
@@ -30,10 +31,10 @@ class ListItemsUseCase(BaseUseCase):
             A list of all items.
 
         """
-        return await self.item_repository.list_items()
+        return await self.items_repository.list_items()
 
 
-class GetItemUseCase(BaseUseCase):
+class GetItemUseCase(BaseItemsUseCase):
     """Use case for retrieving an item by its ID."""
 
     async def execute(self, query: GetItemQuery) -> Item:
@@ -46,13 +47,13 @@ class GetItemUseCase(BaseUseCase):
             ItemNotFoundError: If the item is not found.
 
         """
-        item = await self.item_repository.get_item_by_id(query.item_id)
+        item = await self.items_repository.get_item_by_id(query.item_id)
         if not item:
             raise ItemNotFoundError
         return item
 
 
-class ListOwnerItemsUseCase(BaseUseCase):
+class ListOwnerItemsUseCase(BaseItemsUseCase):
     """Use case for retrieving all items belonging to a specific owner."""
 
     async def execute(self, query: ListOwnerItemsQuery) -> list[Item]:
@@ -65,13 +66,13 @@ class ListOwnerItemsUseCase(BaseUseCase):
             ItemsNotFoundForUserError: If no items are found for the user.
 
         """
-        items = await self.item_repository.list_owner_items(query.owner_id)
+        items = await self.items_repository.list_owner_items(query.owner_id)
         if not len(items) > 0:
             raise ItemsNotFoundForUserError
         return items
 
 
-class GetOwnerItemUseCase(BaseUseCase):
+class GetOwnerItemUseCase(BaseItemsUseCase):
     """Use case for retrieving an item belonging to a specific owner."""
 
     async def execute(self, query: GetOwnerItemQuery) -> Item:
@@ -84,7 +85,7 @@ class GetOwnerItemUseCase(BaseUseCase):
             ItemNotFoundForUserError: If the item is not found for the user.
 
         """
-        item = await self.item_repository.get_owner_item(query.item_id, query.owner_id)
+        item = await self.items_repository.get_owner_item(query.item_id, query.owner_id)
         if not item:
             raise ItemNotFoundForUserError
         return item

--- a/learn_fastapi/src/items/domain/ports.py
+++ b/learn_fastapi/src/items/domain/ports.py
@@ -4,7 +4,7 @@ from learn_fastapi.src.items.domain.entities import Item
 from learn_fastapi.src.shared.domain.value_object import ItemId, UserId
 
 
-class ItemRepository(Protocol):
+class ItemsRepository(Protocol):
     """Protocol for item repository operations."""
 
     async def list_items(self) -> list[Item]: ...

--- a/learn_fastapi/src/items/infrastructure/mappers.py
+++ b/learn_fastapi/src/items/infrastructure/mappers.py
@@ -1,14 +1,14 @@
 from learn_fastapi.src.items.application.dto import ItemDTO
 from learn_fastapi.src.items.domain.entities import Item as ItemDomain
-from learn_fastapi.src.items.models import Item as ItemORM
+from learn_fastapi.src.items.models import Item as ItemModel
 from learn_fastapi.src.items.schema import ItemSchema
 
 
-def item_from_orm(orm_item: ItemORM) -> ItemDomain:
+def item_from_orm(orm_item: ItemModel) -> ItemDomain:
     """Convert an ORM item to a domain item.
 
     Args:
-        orm_item (ItemORM): The ORM item to convert.
+        orm_item (ItemModel): The ORM item to convert.
 
     Returns:
         ItemDomain: The corresponding domain item.
@@ -49,11 +49,11 @@ def item_domain_to_schema(domain_item: ItemDomain) -> ItemSchema:
     )
 
 
-def items_from_orm(orm_items: list[ItemORM]) -> list[ItemDomain]:
+def items_from_orm(orm_items: list[ItemModel]) -> list[ItemDomain]:
     """Convert a list of ORM items to a list of domain items.
 
     Args:
-        orm_items (list[ItemORM]): The list of ORM items to convert.
+        orm_items (list[ItemModel]): The list of ORM items to convert.
 
     Returns:
         list[ItemDomain]: The corresponding list of domain items.

--- a/learn_fastapi/src/items/infrastructure/repository.py
+++ b/learn_fastapi/src/items/infrastructure/repository.py
@@ -1,7 +1,7 @@
 from sqlalchemy import and_, desc, select
 
 from learn_fastapi.src.items.domain.entities import Item as ItemDomain
-from learn_fastapi.src.items.models import Item as ItemORM
+from learn_fastapi.src.items.models import Item as ItemModel
 from learn_fastapi.src.shared.domain.value_object import ItemId, UserId
 from learn_fastapi.src.shared.infrastructure.repository import BaseSQLAlchemyRepository
 from learn_fastapi.src.utils.repository import bool_to_column
@@ -19,7 +19,7 @@ class SQLAlchemyItemRepository(BaseSQLAlchemyRepository):
             A list of all items.
 
         """
-        result = await self.session.execute(select(ItemORM))
+        result = await self.session.execute(select(ItemModel))
         orm_items = list(result.scalars().all())
         return items_from_orm(orm_items)
 
@@ -34,7 +34,7 @@ class SQLAlchemyItemRepository(BaseSQLAlchemyRepository):
 
         """
         result = await self.session.execute(
-            select(ItemORM).where(bool_to_column(ItemORM.id == item_id))
+            select(ItemModel).where(bool_to_column(ItemModel.id == item_id))
         )
         orm_item = result.scalar_one_or_none()
         if not orm_item:
@@ -52,9 +52,9 @@ class SQLAlchemyItemRepository(BaseSQLAlchemyRepository):
 
         """
         result = await self.session.execute(
-            select(ItemORM)
-            .where(ItemORM.user_id == owner_id)
-            .order_by(desc(ItemORM.created_at))
+            select(ItemModel)
+            .where(ItemModel.user_id == owner_id)
+            .order_by(desc(ItemModel.created_at))
         )
         orm_items = list(result.scalars().all())
         return items_from_orm(orm_items)
@@ -73,9 +73,9 @@ class SQLAlchemyItemRepository(BaseSQLAlchemyRepository):
 
         """
         condition = and_(
-            bool_to_column(ItemORM.id == item_id), ItemORM.user_id == owner_id
+            bool_to_column(ItemModel.id == item_id), ItemModel.user_id == owner_id
         )
-        result = await self.session.execute(select(ItemORM).where(condition))
+        result = await self.session.execute(select(ItemModel).where(condition))
         orm_item = result.scalar_one_or_none()
         if not orm_item:
             return None


### PR DESCRIPTION
## Summary

- Clarifies the item repository port naming and use case base class.
- Renames ORM aliases from ItemORM to ItemModel for consistency with the rest of the clean architecture migration.

## Scope

- [x] learn_fastapi - FastAPI backend/API
- [ ] learn_nextjs - Next.js frontend
- [ ] learn_streamlit - Streamlit dashboard/prototype
- [ ] Root/tooling/docs - CI, Docker, dependency management, README, shared config

## Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/build/tooling
- [ ] Dependency update

## Changes

- Renames ItemRepository protocol to ItemsRepository.
- Introduces BaseItemsUseCase as a dataclass for item read use cases.
- Updates item use cases to depend on items_repository naming.
- Renames item infrastructure aliases from ItemORM to ItemModel.

## Behavior and Risk Notes

- [ ] API contract changed
- [ ] Database schema or Alembic migration changed
- [ ] Authentication, authorization, cookies, or security behavior changed
- [ ] Environment variables or secrets configuration changed
- [ ] External service integration changed
- [ ] Media/file upload behavior changed
- [ ] Frontend routing, caching, forms, or protected pages changed
- [x] No high-risk behavior changed

Notes:

- This is a naming and dependency-contract refactor only; route behavior should remain unchanged.

## Validation

### FastAPI

- [ ] uv run pytest --config-file=pyproject.toml
- [x] uv run ruff check learn_fastapi/src/items
- [x] uv run ruff format --check learn_fastapi/src/items
- [x] uv run ty check learn_fastapi/src/items
- [x] DEBUG=True uv run pytest --config-file=pyproject.toml learn_fastapi/tests/v1/items
- [x] Alembic migration reviewed, if applicable
- [x] External services are mocked or safely isolated in tests, if applicable

### Repository

- [x] No real secrets, credentials, tokens, or private keys were committed
- [x] Large files and generated artifacts were not committed unintentionally

## Screenshots or Evidence

- Items scoped tests: 59 passed.
- Combined pre-split validation also passed: 81 tests.

## Reviewer Notes

- This PR is split from the users write-use-case refactor because the item changes are independent naming/contract cleanup.