### PR TITLE
[repo] Harden SSE event delivery across backend and frontend

### DIFF
--- a/.github/workflows/nextjs.yaml
+++ b/.github/workflows/nextjs.yaml
@@ -40,4 +40,4 @@ jobs:
         run: bun tsc
 
       - name: Run Vitest
-        run: bun test
+        run: bun run test

--- a/learn_fastapi/src/items/infrastructure/events.py
+++ b/learn_fastapi/src/items/infrastructure/events.py
@@ -13,7 +13,7 @@ class ItemEventRecord(BaseModel):
     """Public payload sent from SSE for an item."""
 
     id: ItemId
-    owner_id: UserId
+    user_id: UserId
     name: str
     description: str
     price: float
@@ -25,7 +25,7 @@ class ItemEventRecord(BaseModel):
     def from_domain(cls, item: PublishableItem) -> ItemEventRecord:
         return cls(
             id=item.id,
-            owner_id=item.owner_id,
+            user_id=item.owner_id,
             name=item.name,
             description=item.description,
             price=item.price,

--- a/learn_fastapi/src/sse/manager.py
+++ b/learn_fastapi/src/sse/manager.py
@@ -52,7 +52,7 @@ class SSEManager:
             A new asyncio.Queue that will receive all global events.
 
         """
-        queue: asyncio.Queue[str] = asyncio.Queue()
+        queue: asyncio.Queue[str] = asyncio.Queue(maxsize=100)
         self._global.append(queue)
         logger.debug(f"[SSE] Global subscription created. Total: {len(self._global)}")
         return queue
@@ -141,6 +141,13 @@ class SSEManager:
         """
         return user_id in self._users
 
+    def _enqueue(self, queue: asyncio.Queue[str], message: str) -> None:
+        """Enqueue without allowing a slow SSE client to block publishers."""
+        try:
+            queue.put_nowait(message)
+        except asyncio.QueueFull:
+            logger.warning(f"[SSE] Queue full or slow connection for {queue}")
+
     async def broadcast_global(self, event: str, payload: JSONObject) -> None:
         """Broadcast an event to all globally connected clients.
 
@@ -151,10 +158,10 @@ class SSEManager:
         """
         try:
             message = self.build_event_message(event, payload)
-            tasks = [queue.put(message) for queue in self._global]
-            if tasks:
-                await asyncio.gather(*tasks, return_exceptions=True)
-                logger.debug(f"[SSE] Broadcast global: {event} to {len(tasks)} clients")
+            for queue in self._global:
+                self._enqueue(queue, message)
+
+            logger.debug(f"[SSE] Broadcast global: {event}")
         except Exception:
             logger.exception(f"[SSE] Error broadcasting global event: {event}")
 

--- a/learn_fastapi/src/sse/presentation/router.py
+++ b/learn_fastapi/src/sse/presentation/router.py
@@ -14,6 +14,21 @@ from learn_fastapi.src.utils.alembic import app_logger as logger
 router = APIRouter(prefix="/events", tags=["events"])
 
 
+async def _queue_messages(queue: asyncio.Queue) -> AsyncGenerator[str]:
+    """Yield queued SSE messages and periodic keep-alive frames.
+
+    Yields:
+        SSE messages from the event generator.
+
+    """
+    while True:
+        try:
+            yield await asyncio.wait_for(queue.get(), timeout=30.0)
+        except TimeoutError:
+            # Keep the connection alive while the queue has no new events.
+            yield ": keep-alive\n\n"
+
+
 async def event_generator(
     queue: asyncio.Queue,
 ) -> AsyncGenerator[str]:
@@ -32,15 +47,9 @@ async def event_generator(
 
     """
     try:
-        # why: emit a first frame immediately so clients/tests do not block
-        # while waiting for the first timeout cycle.
         yield ": connected\n\n"
-        while True:
-            try:
-                yield await asyncio.wait_for(queue.get(), timeout=30.0)
-            except TimeoutError:
-                # Send a keep-alive comment to detect disconnections
-                yield ": keep-alive\n\n"
+        async for message in _queue_messages(queue):
+            yield message
     except asyncio.CancelledError:
         logger.debug("[SSE] Client disconnected from event stream")
         raise

--- a/learn_fastapi/src/users/application/use_cases.py
+++ b/learn_fastapi/src/users/application/use_cases.py
@@ -61,9 +61,8 @@ class GetAccountUseCase:
     async def execute(self, query: GetAccountQuery) -> PersistedUser:
         """Return the requested account when the actor is authorized.
 
-        Raises:
-            OnlyOwnerIsAuthorizedError: If the actor cannot read the account.
-            UserDoesntExistError: If the requested account does not exist.
+        Returns:
+            PersistedUser: The requested account.
 
         """
         _authorize_account(query.actor, query.user_id)
@@ -158,8 +157,6 @@ class UpdateUserUseCase(BaseUsersUseCase):
             changed_fields: A list of the fields to update.
 
         Raises:
-            OnlyOwnerIsAuthorizedError: If the actor cannot update the account.
-            IncorrectPasswordError: If the actor password is incorrect.
             UserDoesntExistError: Raised when the user doesn't exist.
             UserAlreadyExistsError: Raised when account with that email already exist.
 
@@ -230,27 +227,36 @@ class DeleteAccountUseCase:
         """Authorize, verify, delete, and publish the account event.
 
         Raises:
-            OnlyOwnerIsAuthorizedError: If the actor cannot delete the account.
-            IncorrectPasswordError: If the actor password is incorrect.
             UserDoesntExistError: If the requested account does not exist.
 
         """
-        _authorize_account(command.actor.to_actor(), command.user_id)
+        actor = command.actor.to_actor()
+        user_id = command.user_id
+        _authorize_account(actor, user_id)
+
         _verify_password(
             command.current_password,
             command.actor,
             self.password_hasher,
         )
-        user_to_delete = await self.get_user_by_id.execute(
-            GetUserByIdQuery(command.user_id)
-        )
+
+        try:
+            user_to_delete = await self.get_user_by_id.execute(
+                GetUserByIdQuery(command.user_id)
+            )
+        except UserDoesntExistError as exc:
+            raise UserDoesntExistError from exc
         await self.delete_user.execute(command.user_id)
         await self.event_publisher.account_deleted(user_to_delete)
 
 
 def _authorize_account(actor: CurrentActor, user_id: UserId) -> None:
-    """Enforce owner-or-superuser access for account operations."""
-    # Keeping this rule in application makes it consistent across HTTP and future APIs.
+    """Enforce owner-or-superuser access for account operations.
+
+    Raises:
+        OnlyOwnerIsAuthorizedError: If the actor cannot read the account.
+
+    """
     if not actor.is_superuser and actor.id != user_id:
         raise OnlyOwnerIsAuthorizedError
 
@@ -260,6 +266,11 @@ def _verify_password(
     actor: AuthenticatedAccount,
     password_hasher: PasswordHasher,
 ) -> None:
-    """Verify the authenticated actor's current password."""
+    """Verify the authenticated actor's current password.
+
+    Raises:
+        IncorrectPasswordError: If the password is incorrect.
+
+    """
     if not password_hasher.verify(password, actor.password_hash):
         raise IncorrectPasswordError

--- a/learn_fastapi/src/users/infrastructure/events.py
+++ b/learn_fastapi/src/users/infrastructure/events.py
@@ -1,33 +1,5 @@
-from pydantic import BaseModel
-
-from learn_fastapi.src.shared.domain.value_object import ItemId, RefreshTokenId, UserId
-from learn_fastapi.src.shared.infrastructure.json_types import (
-    model_dump_json_object,
-)
 from learn_fastapi.src.sse.manager import sse_manager
 from learn_fastapi.src.users.domain.entities import PersistedUser
-
-
-class UsersEventRecord(BaseModel):
-    """Public payload sent from SSE for a user."""
-
-    id: UserId
-    items_ids: list[ItemId]
-    refresh_tokens_ids: list[RefreshTokenId]
-    email: str
-    is_active: bool
-    is_superuser: bool
-
-    @classmethod
-    def from_domain(cls, user: PersistedUser) -> UsersEventRecord:
-        return cls(
-            id=user.id,
-            items_ids=user.items_ids,
-            refresh_tokens_ids=user.refresh_tokens_ids,
-            email=user.email,
-            is_active=user.is_active,
-            is_superuser=user.is_superuser,
-        )
 
 
 class SSEUsersEventPublisher:
@@ -35,26 +7,19 @@ class SSEUsersEventPublisher:
 
     @staticmethod
     async def account_updated(user: PersistedUser, changed_fields: list[str]) -> None:
-        user_id = model_dump_json_object(
-            UsersEventRecord.from_domain(user), include={"id"}
-        )
-        payload = {"user_id": user_id, "changed_fields": changed_fields}
-
         await sse_manager.broadcast_user(
             user.id,
             "user.account_updated",
-            payload,
+            {
+                "user_id": str(user.id),
+                "changed_fields": changed_fields,
+            },
         )
 
     @staticmethod
     async def account_deleted(user: PersistedUser) -> None:
-        user_id = model_dump_json_object(
-            UsersEventRecord.from_domain(user), include={"id"}
-        )
-        payload = {"user_id": user_id}
-
         await sse_manager.broadcast_user(
             user.id,
             "user.account_deleted",
-            payload,
+            {"user_id": str(user.id)},
         )

--- a/learn_fastapi/src/users/presentation/router.py
+++ b/learn_fastapi/src/users/presentation/router.py
@@ -121,4 +121,5 @@ async def delete_account(
     except UserDoesntExistError as exc:
         raise user_doesnt_exist_exception() from exc
 
-    clear_auth_cookies(response)
+    if current_user.id == user_id:
+        clear_auth_cookies(response)

--- a/learn_fastapi/tests/v1/sse/test_sse.py
+++ b/learn_fastapi/tests/v1/sse/test_sse.py
@@ -1,5 +1,6 @@
 """Tests for SSE (Server-Sent Events) functionality."""
 
+import asyncio
 import json
 from uuid import uuid4
 
@@ -114,6 +115,25 @@ class TestSSEBroadcast:
         # Clean up
         sse_manager.unsubscribe_global(queue1)
         sse_manager.unsubscribe_global(queue2)
+
+    @pytest.mark.asyncio
+    async def test_full_global_queue_does_not_block_broadcast(
+        self,
+        test_item_data: dict[str, str | float],
+    ) -> None:
+        """Verify that a slow global subscriber cannot block publishers."""
+        queue = sse_manager.subscribe_global()
+        for _ in range(queue.maxsize):
+            queue.put_nowait("queued event")
+
+        try:
+            await asyncio.wait_for(
+                sse_manager.broadcast_global("item.created", test_item_data),
+                timeout=1.0,
+            )
+            assert queue.full()
+        finally:
+            sse_manager.unsubscribe_global(queue)
 
 
 class TestSSEConnectionCleanup:

--- a/learn_nextjs/src/__tests__/app/api/sse-route.test.ts
+++ b/learn_nextjs/src/__tests__/app/api/sse-route.test.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from 'next/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/sse/[channel]/route'
+
+const requestWithAccessToken = () =>
+  new NextRequest('http://localhost/api/sse/me', {
+    headers: { Cookie: 'access_token=expired-token' }
+  })
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('SSE proxy route', () => {
+  it('preserves an upstream authentication failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(
+          Response.json({ detail: 'Invalid or expired token' }, { status: 401 })
+        )
+    )
+
+    const response = await GET(requestWithAccessToken(), {
+      params: Promise.resolve({ channel: 'me' })
+    })
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get('Content-Type')).toContain('application/json')
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Invalid or expired token'
+    })
+  })
+
+  it('continues streaming a successful upstream response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('data: {"event":"item.created","payload":{}}\n\n', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' }
+        })
+      )
+    )
+
+    const response = await GET(requestWithAccessToken(), {
+      params: Promise.resolve({ channel: 'me' })
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream')
+    await expect(response.text()).resolves.toContain('"item.created"')
+  })
+})

--- a/learn_nextjs/src/__tests__/app/hooks/sse.helpers.test.ts
+++ b/learn_nextjs/src/__tests__/app/hooks/sse.helpers.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createSSEMessageHandler } from '@/app/hooks/sse.helpers'
+
+describe('createSSEMessageHandler', () => {
+  it('delivers each incoming message exactly once', () => {
+    const onEvent = vi.fn()
+    const handleMessage = createSSEMessageHandler(onEvent)
+
+    handleMessage(
+      new MessageEvent('message', {
+        data: JSON.stringify({ event: 'item.created', payload: { id: 'one' } })
+      })
+    )
+    handleMessage(
+      new MessageEvent('message', {
+        data: JSON.stringify({ event: 'item.updated', payload: { id: 'two' } })
+      })
+    )
+
+    expect(onEvent).toHaveBeenCalledTimes(2)
+    expect(onEvent).toHaveBeenNthCalledWith(1, {
+      event: 'item.created',
+      payload: { id: 'one' }
+    })
+    expect(onEvent).toHaveBeenNthCalledWith(2, {
+      event: 'item.updated',
+      payload: { id: 'two' }
+    })
+  })
+})

--- a/learn_nextjs/src/app/api/sse/[channel]/route.ts
+++ b/learn_nextjs/src/app/api/sse/[channel]/route.ts
@@ -23,6 +23,17 @@ const handler = async (
       }
     )
 
+    if (!fastapiResponse.ok) {
+      // Preserve FastAPI's status so EventSource follows its error path.
+      return new NextResponse(fastapiResponse.body, {
+        status: fastapiResponse.status,
+        headers: {
+          'Content-Type':
+            fastapiResponse.headers.get('Content-Type') ?? 'application/json'
+        }
+      })
+    }
+
     const readable = fastapiResponse.body
     if (!readable) throw new Error('No stream found in response')
 

--- a/learn_nextjs/src/app/components/notifications/toasts.tsx
+++ b/learn_nextjs/src/app/components/notifications/toasts.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useCallback } from 'react'
 import type {
   SSEEvent,
   SSEEventMap,
@@ -12,11 +12,12 @@ import { globalEventMap, userEventMap } from './events'
 import { invokeHandler } from './toasts.helpers'
 
 const NotificationListener = ({ channel, eventMap }: SSEToastProps) => {
-  const { events } = useSSE<SSEEvent>(channel, true)
+  const handleEvent = useCallback(
+    (event: SSEEvent) => invokeHandler(eventMap, event),
+    [eventMap]
+  )
 
-  useEffect(() => {
-    for (const event of events) invokeHandler(eventMap, event)
-  }, [events, eventMap])
+  useSSE<SSEEvent>(channel, true, handleEvent)
 
   return null
 }

--- a/learn_nextjs/src/app/hooks/sse.helpers.ts
+++ b/learn_nextjs/src/app/hooks/sse.helpers.ts
@@ -1,0 +1,5 @@
+export const createSSEMessageHandler =
+  <T>(onEvent: (event: T) => void) =>
+  (message: { data: string }) => {
+    onEvent(JSON.parse(message.data) as T)
+  }

--- a/learn_nextjs/src/app/hooks/useSSE.ts
+++ b/learn_nextjs/src/app/hooks/useSSE.ts
@@ -2,17 +2,24 @@ import { EventSourcePolyfill } from 'event-source-polyfill'
 import { useEffect, useRef, useState } from 'react'
 import { NEXT_API_PROXY_PREFIX } from '@/common/const'
 import type { SSEBaseEvent } from '../api/sse/[channel]/types'
+import { createSSEMessageHandler } from './sse.helpers'
 
 export const useSSE = <T extends SSEBaseEvent>(
   channel: string,
-  enabled: boolean
+  enabled: boolean,
+  onEvent: (event: T) => void
 ) => {
   const eventSourceRef = useRef<EventSourcePolyfill | null>(null)
+  const onEventRef = useRef(onEvent)
 
-  const [events, setEvents] = useState<T[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
   const [isConnected, setIsConnected] = useState<boolean>(false)
+
+  useEffect(() => {
+    // Keep callback changes from reconnecting an otherwise healthy SSE stream.
+    onEventRef.current = onEvent
+  }, [onEvent])
 
   useEffect(() => {
     if (!enabled) {
@@ -44,10 +51,9 @@ export const useSSE = <T extends SSEBaseEvent>(
       setError(null)
     }
 
-    eventSource.onmessage = (event) => {
-      const data: T = JSON.parse(event.data)
-      setEvents((prevEvents) => [...prevEvents, data])
-    }
+    eventSource.onmessage = createSSEMessageHandler((event: T) =>
+      onEventRef.current(event)
+    )
 
     eventSource.onerror = () => {
       setIsConnected(false)
@@ -63,5 +69,5 @@ export const useSSE = <T extends SSEBaseEvent>(
     }
   }, [channel, enabled])
 
-  return { events, error, isConnected, isLoading }
+  return { error, isConnected, isLoading }
 }


### PR DESCRIPTION
## Summary

- Prevent slow global SSE subscribers from blocking API publishers.
- Align backend SSE payloads with the frontend event contracts.
- Deliver each frontend notification once and preserve upstream SSE error statuses.
- Preserve an administrator session when deleting another account while clearing cookies for self-deletion.

## Scope

- [x] `learn_fastapi` - FastAPI backend/API
- [x] `learn_nextjs` - Next.js frontend
- [ ] `learn_streamlit` - Streamlit dashboard/prototype
- [ ] Root/tooling/docs - CI, Docker, dependency management, README, shared config

## Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Documentation
- [ ] CI/build/tooling
- [ ] Dependency update

## Changes

- Bound global subscriber queues and use non-blocking enqueue with an overflow policy.
- Extract SSE queue consumption while preserving connected and keep-alive frames.
- Normalize item and user event payload field names and JSON values.
- Clear authentication cookies only when the authenticated account deletes itself.
- Forward FastAPI SSE failures with their original HTTP status and content type.
- Replace accumulated SSE event history with callback-based delivery to prevent repeated toasts.
- Add backend queue saturation coverage and frontend proxy/message-dispatch tests.

## Behavior and Risk Notes

- [x] API contract changed
- [ ] Database schema or Alembic migration changed
- [x] Authentication, authorization, cookies, or security behavior changed
- [ ] Environment variables or secrets configuration changed
- [ ] External service integration changed
- [ ] Media/file upload behavior changed
- [ ] Frontend routing, caching, forms, or protected pages changed
- [ ] No high-risk behavior changed

Notes:

- Item SSE payloads now expose `user_id`; user account events expose `user_id` as a JSON string.
- A saturated global SSE queue drops the new event for that slow subscriber instead of blocking the publishing HTTP operation.
- README rewrites present in the local worktree were intentionally excluded from this PR.

## Validation

### FastAPI

- [x] `uv run pytest --config-file=pyproject.toml` - 100 passed
- [x] `uv run ruff check learn_fastapi`
- [x] `uv run ruff format --check learn_fastapi`
- [x] `uv run ty check learn_fastapi`
- [x] Alembic migration reviewed, if applicable - no migration changes
- [x] External services are mocked or safely isolated in tests, if applicable

### Next.js

- [x] `bun run test` - 62 passed
- [ ] `bun run check` - blocked by 13 pre-existing formatting errors outside this PR; scoped SSE Biome check passes
- [x] `bun run tsc`
- [ ] `bun run build`
- [ ] Relevant UI flow checked manually, if applicable

### Streamlit

- [ ] App starts locally with `uv run streamlit run learn_streamlit/src/app.py`
- [ ] Relevant dashboard/data flow checked manually, if applicable

### Repository

- [ ] `.env.example` or related docs updated for any configuration changes
- [x] No real secrets, credentials, tokens, or private keys were committed
- [x] Large files and generated artifacts were not committed unintentionally
- [ ] Documentation updated where behavior changed

## Screenshots or Evidence

- Backend: 100 tests passed.
- Frontend: 62 tests passed.
- Scoped Biome validation passed for all touched SSE frontend files.

## Reviewer Notes

- Please pay particular attention to the bounded-queue overflow policy and the SSE payload contract changes.
